### PR TITLE
Updated theme to make modal-based components visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,15 @@ This is an example of a brief overview of the _Major_ or _Minor_ version changes
 
 ---
 
+## [2.8] Material ui theme
+
+#### **Changes**
+- Gives modals and <Modal>-based components a z-index of 9999
+
 ## [2.7] data-tests
 
 #### **Changes**
 - Adds dataTest props to Flex and Flex-Item
-
 
 ## [2.6] `easing` standards
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@
 * Jenkins populates the patch version depending on the branch.
 */
 
-String VERSION = "2.7"
+String VERSION = "2.8"
 
 /* ---- DO NOT EDIT BELOW (unless you really know what you're doing) ---- */
 

--- a/packages/fds-mui-theme/index.js
+++ b/packages/fds-mui-theme/index.js
@@ -37,4 +37,7 @@ module.exports = {
     MuiButton,
     MuiIconButton,
   },
+  zIndex: {
+    modal: 9999,
+  }
 };


### PR DESCRIPTION
## Packages changed
<!-- check all that apply -->
- [ ] `fds-dictionary`
- [ ] `fds-styles`
- [ ] `fds-components`
- [x] `fds-mui-theme`
- [ ] `fds-icons`

## Description
Some components aren't visible when used within a modal unless they're given a z-index of 9999. These components have `<Modal>` as a base class so this small change fixes all of them.

## Checklist
- [ ] Docs have been rebuilt (`yarn build:full`)
- [ ] All unit tests pass
- [ ] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [x] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**

