### PR TITLE
add CSS dist for custom media properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ This is an example of a brief overview of the _Major_ or _Minor_ version changes
 
 ---
 
+## [2.14] Custom Media
+
+#### **Changes**
+- Added [custom media](https://preset-env.cssdb.org/features#custom-media-queries)
+  properties to `fds-dictionary`.
+
 ## [2.13] `ShareIcon`
 
 #### **Changes**

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@
 * Jenkins populates the patch version depending on the branch.
 */
 
-String VERSION = "2.13"
+String VERSION = "2.14"
 
 /* ---- DO NOT EDIT BELOW (unless you really know what you're doing) ---- */
 

--- a/docs/fds-styles/index.html
+++ b/docs/fds-styles/index.html
@@ -750,7 +750,7 @@ of clamping text to one line.</p>
         </main>
       </div>
       <footer class="footer">
-        Last modified Thursday, 2 May 2019 10:18
+        Last modified Thursday, 2 May 2019 14:05
       </footer>
     </div>
     <script src="prism.js?871234"></script>

--- a/packages/fds-dictionary/properties/customMedia/all.json
+++ b/packages/fds-dictionary/properties/customMedia/all.json
@@ -1,0 +1,13 @@
+{
+  "customMedia": {
+    "all": {
+
+      "xs":  { "value": "(min-width: 320px)" },
+      "s":   { "value": "(min-width: 480px)" },
+      "m":   { "value": "(min-width: 768px)" },
+      "l":   { "value": "(min-width: 1024px)" },
+      "xl":  { "value": "(min-width: 1280px)" }
+
+    }
+  }
+}

--- a/packages/fds-dictionary/scripts/formats.js
+++ b/packages/fds-dictionary/scripts/formats.js
@@ -98,22 +98,26 @@ const formatCommonJs = (dictionary) =>
     .join('\n');
 
 /**
- * @param {dictionary} dictionary style-dictionary dictionary
+ * @param {Object} filteredDictionary dictionary category-filtered by config
  * @return {String} js file for colors in the CBI React Native app
  */
-const formatReactNativeColors = (dictionary) =>
+const formatReactNativeColors = (filteredDictionary) =>
   [
     `${jsComment()}`,
     'module.exports = {',
-    ...dictionary.allProperties.map((prop) => `  ${prop.name}: '${prop.value}',`),
+    ...filteredDictionary.allProperties.map((prop) => `  ${prop.name}: '${prop.value}',`),
     '};',
   ].join('\n');
 
-const formatMaterialPalette = (dictionary) =>
+/**
+ * @param {Object} filteredDictionary dictionary category-filtered by config
+ * @return {String} js file with commonjs export of tint/shade objects for each color
+ */
+const formatMaterialPalette = (filteredDictionary) =>
   [
     `${jsComment()}`,
     'module.exports = {',
-    ...dictionary.allProperties.map((prop) => {
+    ...filteredDictionary.allProperties.map((prop) => {
       const paletteProps = Object.keys(prop.attributes.materialPalette)
         .map((k) => `    ${k}: '${prop.attributes.materialPalette[k]}',`)
         .join('\n');
@@ -121,6 +125,25 @@ const formatMaterialPalette = (dictionary) =>
       return `  ${prop.name}: {\n${paletteProps}\n  },`;
     }),
     '};',
+  ].join('\n');
+
+/**
+ * @param {Object} filteredDictionary dictionary category-filtered by config
+ * @return {String} css file with "custom media" declarations (uses PostCSS to polyfill)
+ */
+const formatCssCustomMedia = (filteredDictionary) =>
+  [
+    `${jsComment()}`,
+    `/**
+* Usage (relies on postcss-preset-env Stage 1 polyfills):
+*
+* @media (--viewport-s) {
+*   ...styles that target small viewports AND larger...
+* }
+*/`,
+    ...filteredDictionary.allProperties.map(
+      (prop) => `@custom-media --viewport-${prop.name} ${prop.value};`
+    ),
   ].join('\n');
 
 // Custom formats
@@ -144,5 +167,9 @@ module.exports = [
   {
     name: 'javascript/materialPalette',
     formatter: formatMaterialPalette,
+  },
+  {
+    name: 'css/customMedia',
+    formatter: formatCssCustomMedia,
   },
 ];

--- a/packages/fds-dictionary/scripts/transforms.js
+++ b/packages/fds-dictionary/scripts/transforms.js
@@ -30,6 +30,9 @@ const getNameParts = (prop) => {
   const { category, type, item } = getCTI(prop);
 
   switch (category) {
+    case 'customMedia':
+      nameParts = [item];
+      break;
     case 'color':
       nameParts = [category, item];
       break;
@@ -126,7 +129,7 @@ module.exports = [
     transformer: toItemName,
   },
   {
-    name: 'name/ci/kebab',
+    name: 'name/custom/kebab',
     type: 'name',
     transformer: toKebab,
   },

--- a/packages/fds-dictionary/style-dictionary.config.json
+++ b/packages/fds-dictionary/style-dictionary.config.json
@@ -27,11 +27,10 @@
       }]
     },
 
-
     "CssCustomProperties": {
       "transforms": [
         "attribute/cti",
-        "name/ci/kebab",
+        "name/custom/kebab",
         "color/css"
       ],
       "buildPath": "./dist/css/",
@@ -41,10 +40,23 @@
       }]
     },
 
+    "CssCustomMedia": {
+      "transforms": [
+        "attribute/cti",
+        "name/custom/kebab"
+      ],
+      "buildPath": "./dist/css/",
+      "files": [{
+        "filter": "isCustomMedia",
+        "destination": "customMedia.css",
+        "format": "css/customMedia"
+      }]
+    },
+
     "JSCustomProperties": {
       "transforms": [
         "attribute/cti",
-        "name/ci/kebab",
+        "name/custom/kebab",
         "color/css"
       ],
       "buildPath": "./dist/js/",


### PR DESCRIPTION
## Packages changed
<!-- check all that apply -->
- [x] `fds-dictionary`
- [ ] `fds-styles`
- [ ] `fds-components`
- [ ] `fds-mui-theme`
- [ ] `fds-icons`

## Description
- Refactor some transforms for style-dictionary to add clarity on filtering
- Add custom media formatter
- Add `CssCustomMedia` dist to style-dictionary config

## Output
```
/**
* DO NOT EDIT
* Generated by fds-dictionary on Thu May 02 2019 13:50:48 GMT-0400 (Eastern Daylight Time)
* github.com/cbinsights/form-design-system/
*/


/**
* Usage (relies on postcss-preset-env Stage 1 polyfills):
*
* @media (--viewport-s) {
*   ...styles that target small viewports AND larger...
* }
*/
@custom-media --viewport-xs (min-width: 320px);
@custom-media --viewport-s (min-width: 480px);
@custom-media --viewport-m (min-width: 768px);
@custom-media --viewport-l (min-width: 1024px);
@custom-media --viewport-xl (min-width: 1280px);
```

## Checklist
- [x] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [x] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**

