### PR TITLE
remove autoprefixer

### DIFF
--- a/postcss.plugins.js
+++ b/postcss.plugins.js
@@ -1,6 +1,5 @@
 module.exports = [
   require('postcss-import'),
-  require('autoprefixer'),
   require('postcss-preset-env')({
     autoprefixer: {
       grid: true,


### PR DESCRIPTION
## Description
I actually didn't see this anywhere in our package.json. Storybook pulls this dependency in though,
so it's in our lock file. I did remove it from `postcss.plugins.js` though.

## Screenshots
N/A

## Checklist
- [x] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [x] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**