### PR TITLE
UIP-257: fix tests being added to lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "icons:transpile": "babel ./lib/icons/react --out-dir ./lib/icons/react",
     "icons:css": "cp src/icons/style/icons.css ./lib/icons/style/icons.css",
     "icons:docs": "node ./scripts/node/icons/buildDocs.js",
-    "comp:jsx": "babel src --out-dir=lib --ignore=test.jsx --source-maps",
+    "comp:jsx": "babel src --out-dir=lib --ignore=**/*.test.{js,jsx} --source-maps",
     "comp:css": "postcss src/components/style/index.css -o ./lib/components/style/fds-components.css --config=./postcss.config.js",
     "comp:docs": "build-storybook -c .storybook -o ./docs/fds-components/",
     "test": "jest --color",


### PR DESCRIPTION
## Description
Tests are currently being added to lib when running `yarn comp:jsx`. The ignore argument wasn't working, because tests need to be globbed for to match them.

 If you blow away the lib folder now, running yarn test should not have any tests running from lib, and you shouldn't be able to find any tests in lib

## Screenshots
N/A

## Checklist
- [x] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [x] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**