### PR TITLE
Remove modal content blurriness when scrollable

### DIFF
--- a/src/components/modals/Dialog.jsx
+++ b/src/components/modals/Dialog.jsx
@@ -58,52 +58,54 @@ const Dialog = (props) => {
         <FocusTrap>
           <div>
             <div className="dialog-overlay" onClick={props.onDimiss}></div>
-            <div
-              className="dialog elevation--3"
-              role={props.role}
-              aria-labelledby={props.title && 'a11y-dialog-title'}
-              aria-describedby="a11y-dialog-desc"
-              tabIndex="-1"
-              aria-modal="true"
-              onKeyDown={handleKeyDown}
-            >
-              {(props.title || props.onDismiss) && (
-                <React.Fragment>
-                  <div className="dialog-header">
-                    <Section border="bottom">
-                      <Flex justify="spaceBetween" align="start">
-                        <FlexItem>
-                          {props.title && (
-                            <div
-                              className="dialog-title type--head4"
-                              id="a11y-dialog-title"
-                            >
-                              {props.title}
-                            </div>
-                          )}
-                        </FlexItem>
-                        {props.onDismiss && (
-                          <FlexItem shrink>
-                            <button className="dialog-icon" onClick={props.onDismiss}>
-                              <DenyIcon size="xs" />
-                            </button>
+            <div className="dialog-wrapper">
+              <div
+                className="dialog elevation--3"
+                role={props.role}
+                aria-labelledby={props.title && 'a11y-dialog-title'}
+                aria-describedby="a11y-dialog-desc"
+                tabIndex="-1"
+                aria-modal="true"
+                onKeyDown={handleKeyDown}
+              >
+                {(props.title || props.onDismiss) && (
+                  <React.Fragment>
+                    <div className="dialog-header">
+                      <Section border="bottom">
+                        <Flex justify="spaceBetween" align="start">
+                          <FlexItem>
+                            {props.title && (
+                              <div
+                                className="dialog-title type--head4"
+                                id="a11y-dialog-title"
+                              >
+                                {props.title}
+                              </div>
+                            )}
                           </FlexItem>
-                        )}
-                      </Flex>
+                          {props.onDismiss && (
+                            <FlexItem shrink>
+                              <button className="dialog-icon" onClick={props.onDismiss}>
+                                <DenyIcon size="xs" />
+                              </button>
+                            </FlexItem>
+                          )}
+                        </Flex>
+                      </Section>
+                    </div>
+                  </React.Fragment>
+                )}
+                <div className="dialog-content" ref={contentEl}>
+                  <Section>{props.content}</Section>
+                </div>
+                {props.footerContent && (
+                  <div className="dialog-footer">
+                    <Section border={isOverflowing ? 'top' : undefined} bgColor="white">
+                      {props.footerContent}
                     </Section>
                   </div>
-                </React.Fragment>
-              )}
-              <div className="dialog-content" ref={contentEl}>
-                <Section>{props.content}</Section>
+                )}
               </div>
-              {props.footerContent && (
-                <div className="dialog-footer">
-                  <Section border={isOverflowing ? 'top' : undefined} bgColor="white">
-                    {props.footerContent}
-                  </Section>
-                </div>
-              )}
             </div>
           </div>
         </FocusTrap>

--- a/src/components/modals/__snapshots__/dialog.test.js.snap
+++ b/src/components/modals/__snapshots__/dialog.test.js.snap
@@ -9,64 +9,68 @@ exports[`Dialog component matches snapshot (default props) 1`] = `
           class="dialog-overlay"
         />
         <div
-          aria-describedby="a11y-dialog-desc"
-          aria-modal="true"
-          class="dialog elevation--3"
-          role="dialog"
-          tabindex="-1"
+          class="dialog-wrapper"
         >
           <div
-            class="dialog-header"
+            aria-describedby="a11y-dialog-desc"
+            aria-modal="true"
+            class="dialog elevation--3"
+            role="dialog"
+            tabindex="-1"
           >
             <div
-              class="bgColor--white display--block padding--left padding--right padding--top padding--bottom border--bottom"
+              class="dialog-header"
             >
               <div
-                class="flex flex--alignStart flex--row flex--justifySpaceBetween"
-                data-test=""
+                class="bgColor--white display--block padding--left padding--right padding--top padding--bottom border--bottom"
               >
                 <div
-                  class="flexItem"
-                  data-test=""
-                />
-                <div
-                  class="flexItem flexItem--shrink"
+                  class="flex flex--alignStart flex--row flex--justifySpaceBetween"
                   data-test=""
                 >
-                  <button
-                    class="dialog-icon"
+                  <div
+                    class="flexItem"
+                    data-test=""
+                  />
+                  <div
+                    class="flexItem flexItem--shrink"
+                    data-test=""
                   >
-                    <div
-                      class="fds-icon fds-icon--xs"
+                    <button
+                      class="dialog-icon"
                     >
-                      <svg
-                        viewBox="0 0 24 24"
+                      <div
+                        class="fds-icon fds-icon--xs"
                       >
-                        <g
-                          fill-rule="evenodd"
+                        <svg
+                          viewBox="0 0 24 24"
                         >
-                          <g>
-                            <polygon
-                              points="10.363961 11.7781746 4 5.41421356 5.41421356 4 11.7781746 10.363961 18.1421356 4 19.5563492 5.41421356 13.1923882 11.7781746 19.5563492 18.1421356 18.1421356 19.5563492 11.7781746 13.1923882 5.41421356 19.5563492 4 18.1421356"
-                            />
+                          <g
+                            fill-rule="evenodd"
+                          >
+                            <g>
+                              <polygon
+                                points="10.363961 11.7781746 4 5.41421356 5.41421356 4 11.7781746 10.363961 18.1421356 4 19.5563492 5.41421356 13.1923882 11.7781746 19.5563492 18.1421356 18.1421356 19.5563492 11.7781746 13.1923882 5.41421356 19.5563492 4 18.1421356"
+                              />
+                            </g>
                           </g>
-                        </g>
-                      </svg>
-                    </div>
-                  </button>
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            class="dialog-content"
-          >
             <div
-              class="bgColor--white display--block padding--left padding--right padding--top padding--bottom"
+              class="dialog-content"
             >
-              <button>
-                hey
-              </button>
+              <div
+                class="bgColor--white display--block padding--left padding--right padding--top padding--bottom"
+              >
+                <button>
+                  hey
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -76,64 +80,68 @@ exports[`Dialog component matches snapshot (default props) 1`] = `
           class="dialog-overlay"
         />
         <div
-          aria-describedby="a11y-dialog-desc"
-          aria-modal="true"
-          class="dialog elevation--3"
-          role="dialog"
-          tabindex="-1"
+          class="dialog-wrapper"
         >
           <div
-            class="dialog-header"
+            aria-describedby="a11y-dialog-desc"
+            aria-modal="true"
+            class="dialog elevation--3"
+            role="dialog"
+            tabindex="-1"
           >
             <div
-              class="bgColor--white display--block padding--left padding--right padding--top padding--bottom border--bottom"
+              class="dialog-header"
             >
               <div
-                class="flex flex--alignStart flex--row flex--justifySpaceBetween"
-                data-test=""
+                class="bgColor--white display--block padding--left padding--right padding--top padding--bottom border--bottom"
               >
                 <div
-                  class="flexItem"
-                  data-test=""
-                />
-                <div
-                  class="flexItem flexItem--shrink"
+                  class="flex flex--alignStart flex--row flex--justifySpaceBetween"
                   data-test=""
                 >
-                  <button
-                    class="dialog-icon"
+                  <div
+                    class="flexItem"
+                    data-test=""
+                  />
+                  <div
+                    class="flexItem flexItem--shrink"
+                    data-test=""
                   >
-                    <div
-                      class="fds-icon fds-icon--xs"
+                    <button
+                      class="dialog-icon"
                     >
-                      <svg
-                        viewBox="0 0 24 24"
+                      <div
+                        class="fds-icon fds-icon--xs"
                       >
-                        <g
-                          fill-rule="evenodd"
+                        <svg
+                          viewBox="0 0 24 24"
                         >
-                          <g>
-                            <polygon
-                              points="10.363961 11.7781746 4 5.41421356 5.41421356 4 11.7781746 10.363961 18.1421356 4 19.5563492 5.41421356 13.1923882 11.7781746 19.5563492 18.1421356 18.1421356 19.5563492 11.7781746 13.1923882 5.41421356 19.5563492 4 18.1421356"
-                            />
+                          <g
+                            fill-rule="evenodd"
+                          >
+                            <g>
+                              <polygon
+                                points="10.363961 11.7781746 4 5.41421356 5.41421356 4 11.7781746 10.363961 18.1421356 4 19.5563492 5.41421356 13.1923882 11.7781746 19.5563492 18.1421356 18.1421356 19.5563492 11.7781746 13.1923882 5.41421356 19.5563492 4 18.1421356"
+                              />
+                            </g>
                           </g>
-                        </g>
-                      </svg>
-                    </div>
-                  </button>
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            class="dialog-content"
-          >
             <div
-              class="bgColor--white display--block padding--left padding--right padding--top padding--bottom"
+              class="dialog-content"
             >
-              <button>
-                hey
-              </button>
+              <div
+                class="bgColor--white display--block padding--left padding--right padding--top padding--bottom"
+              >
+                <button>
+                  hey
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -143,21 +151,25 @@ exports[`Dialog component matches snapshot (default props) 1`] = `
           class="dialog-overlay"
         />
         <div
-          aria-describedby="a11y-dialog-desc"
-          aria-modal="true"
-          class="dialog elevation--3"
-          role="dialog"
-          tabindex="-1"
+          class="dialog-wrapper"
         >
           <div
-            class="dialog-content"
+            aria-describedby="a11y-dialog-desc"
+            aria-modal="true"
+            class="dialog elevation--3"
+            role="dialog"
+            tabindex="-1"
           >
             <div
-              class="bgColor--white display--block padding--left padding--right padding--top padding--bottom"
+              class="dialog-content"
             >
-              <button>
-                hey
-              </button>
+              <div
+                class="bgColor--white display--block padding--left padding--right padding--top padding--bottom"
+              >
+                <button>
+                  hey
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -182,23 +194,27 @@ exports[`Dialog component matches snapshot (default props) 1`] = `
           className="dialog-overlay"
         />
         <div
-          aria-describedby="a11y-dialog-desc"
-          aria-modal="true"
-          className="dialog elevation--3"
-          onKeyDown={[Function]}
-          role="dialog"
-          tabIndex="-1"
+          className="dialog-wrapper"
         >
           <div
-            className="dialog-content"
+            aria-describedby="a11y-dialog-desc"
+            aria-modal="true"
+            className="dialog elevation--3"
+            onKeyDown={[Function]}
+            role="dialog"
+            tabIndex="-1"
           >
-            <Section
-              bgColor="white"
-              xPadding="default"
-              yPadding="default"
+            <div
+              className="dialog-content"
             >
-              foo
-            </Section>
+              <Section
+                bgColor="white"
+                xPadding="default"
+                yPadding="default"
+              >
+                foo
+              </Section>
+            </div>
           </div>
         </div>
       </div>
@@ -216,64 +232,68 @@ exports[`Dialog component matches snapshot (set all props) 1`] = `
           class="dialog-overlay"
         />
         <div
-          aria-describedby="a11y-dialog-desc"
-          aria-modal="true"
-          class="dialog elevation--3"
-          role="dialog"
-          tabindex="-1"
+          class="dialog-wrapper"
         >
           <div
-            class="dialog-header"
+            aria-describedby="a11y-dialog-desc"
+            aria-modal="true"
+            class="dialog elevation--3"
+            role="dialog"
+            tabindex="-1"
           >
             <div
-              class="bgColor--white display--block padding--left padding--right padding--top padding--bottom border--bottom"
+              class="dialog-header"
             >
               <div
-                class="flex flex--alignStart flex--row flex--justifySpaceBetween"
-                data-test=""
+                class="bgColor--white display--block padding--left padding--right padding--top padding--bottom border--bottom"
               >
                 <div
-                  class="flexItem"
-                  data-test=""
-                />
-                <div
-                  class="flexItem flexItem--shrink"
+                  class="flex flex--alignStart flex--row flex--justifySpaceBetween"
                   data-test=""
                 >
-                  <button
-                    class="dialog-icon"
+                  <div
+                    class="flexItem"
+                    data-test=""
+                  />
+                  <div
+                    class="flexItem flexItem--shrink"
+                    data-test=""
                   >
-                    <div
-                      class="fds-icon fds-icon--xs"
+                    <button
+                      class="dialog-icon"
                     >
-                      <svg
-                        viewBox="0 0 24 24"
+                      <div
+                        class="fds-icon fds-icon--xs"
                       >
-                        <g
-                          fill-rule="evenodd"
+                        <svg
+                          viewBox="0 0 24 24"
                         >
-                          <g>
-                            <polygon
-                              points="10.363961 11.7781746 4 5.41421356 5.41421356 4 11.7781746 10.363961 18.1421356 4 19.5563492 5.41421356 13.1923882 11.7781746 19.5563492 18.1421356 18.1421356 19.5563492 11.7781746 13.1923882 5.41421356 19.5563492 4 18.1421356"
-                            />
+                          <g
+                            fill-rule="evenodd"
+                          >
+                            <g>
+                              <polygon
+                                points="10.363961 11.7781746 4 5.41421356 5.41421356 4 11.7781746 10.363961 18.1421356 4 19.5563492 5.41421356 13.1923882 11.7781746 19.5563492 18.1421356 18.1421356 19.5563492 11.7781746 13.1923882 5.41421356 19.5563492 4 18.1421356"
+                              />
+                            </g>
                           </g>
-                        </g>
-                      </svg>
-                    </div>
-                  </button>
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            class="dialog-content"
-          >
             <div
-              class="bgColor--white display--block padding--left padding--right padding--top padding--bottom"
+              class="dialog-content"
             >
-              <button>
-                hey
-              </button>
+              <div
+                class="bgColor--white display--block padding--left padding--right padding--top padding--bottom"
+              >
+                <button>
+                  hey
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -283,64 +303,68 @@ exports[`Dialog component matches snapshot (set all props) 1`] = `
           class="dialog-overlay"
         />
         <div
-          aria-describedby="a11y-dialog-desc"
-          aria-modal="true"
-          class="dialog elevation--3"
-          role="dialog"
-          tabindex="-1"
+          class="dialog-wrapper"
         >
           <div
-            class="dialog-header"
+            aria-describedby="a11y-dialog-desc"
+            aria-modal="true"
+            class="dialog elevation--3"
+            role="dialog"
+            tabindex="-1"
           >
             <div
-              class="bgColor--white display--block padding--left padding--right padding--top padding--bottom border--bottom"
+              class="dialog-header"
             >
               <div
-                class="flex flex--alignStart flex--row flex--justifySpaceBetween"
-                data-test=""
+                class="bgColor--white display--block padding--left padding--right padding--top padding--bottom border--bottom"
               >
                 <div
-                  class="flexItem"
-                  data-test=""
-                />
-                <div
-                  class="flexItem flexItem--shrink"
+                  class="flex flex--alignStart flex--row flex--justifySpaceBetween"
                   data-test=""
                 >
-                  <button
-                    class="dialog-icon"
+                  <div
+                    class="flexItem"
+                    data-test=""
+                  />
+                  <div
+                    class="flexItem flexItem--shrink"
+                    data-test=""
                   >
-                    <div
-                      class="fds-icon fds-icon--xs"
+                    <button
+                      class="dialog-icon"
                     >
-                      <svg
-                        viewBox="0 0 24 24"
+                      <div
+                        class="fds-icon fds-icon--xs"
                       >
-                        <g
-                          fill-rule="evenodd"
+                        <svg
+                          viewBox="0 0 24 24"
                         >
-                          <g>
-                            <polygon
-                              points="10.363961 11.7781746 4 5.41421356 5.41421356 4 11.7781746 10.363961 18.1421356 4 19.5563492 5.41421356 13.1923882 11.7781746 19.5563492 18.1421356 18.1421356 19.5563492 11.7781746 13.1923882 5.41421356 19.5563492 4 18.1421356"
-                            />
+                          <g
+                            fill-rule="evenodd"
+                          >
+                            <g>
+                              <polygon
+                                points="10.363961 11.7781746 4 5.41421356 5.41421356 4 11.7781746 10.363961 18.1421356 4 19.5563492 5.41421356 13.1923882 11.7781746 19.5563492 18.1421356 18.1421356 19.5563492 11.7781746 13.1923882 5.41421356 19.5563492 4 18.1421356"
+                              />
+                            </g>
                           </g>
-                        </g>
-                      </svg>
-                    </div>
-                  </button>
+                        </svg>
+                      </div>
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            class="dialog-content"
-          >
             <div
-              class="bgColor--white display--block padding--left padding--right padding--top padding--bottom"
+              class="dialog-content"
             >
-              <button>
-                hey
-              </button>
+              <div
+                class="bgColor--white display--block padding--left padding--right padding--top padding--bottom"
+              >
+                <button>
+                  hey
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -350,21 +374,25 @@ exports[`Dialog component matches snapshot (set all props) 1`] = `
           class="dialog-overlay"
         />
         <div
-          aria-describedby="a11y-dialog-desc"
-          aria-modal="true"
-          class="dialog elevation--3"
-          role="dialog"
-          tabindex="-1"
+          class="dialog-wrapper"
         >
           <div
-            class="dialog-content"
+            aria-describedby="a11y-dialog-desc"
+            aria-modal="true"
+            class="dialog elevation--3"
+            role="dialog"
+            tabindex="-1"
           >
             <div
-              class="bgColor--white display--block padding--left padding--right padding--top padding--bottom"
+              class="dialog-content"
             >
-              <button>
-                hey
-              </button>
+              <div
+                class="bgColor--white display--block padding--left padding--right padding--top padding--bottom"
+              >
+                <button>
+                  hey
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -389,79 +417,83 @@ exports[`Dialog component matches snapshot (set all props) 1`] = `
           className="dialog-overlay"
         />
         <div
-          aria-describedby="a11y-dialog-desc"
-          aria-labelledby="a11y-dialog-title"
-          aria-modal="true"
-          className="dialog elevation--3"
-          onKeyDown={[Function]}
-          role="alertdialog"
-          tabIndex="-1"
+          className="dialog-wrapper"
         >
           <div
-            className="dialog-header"
+            aria-describedby="a11y-dialog-desc"
+            aria-labelledby="a11y-dialog-title"
+            aria-modal="true"
+            className="dialog elevation--3"
+            onKeyDown={[Function]}
+            role="alertdialog"
+            tabIndex="-1"
           >
-            <Section
-              bgColor="white"
-              border="bottom"
-              xPadding="default"
-              yPadding="default"
+            <div
+              className="dialog-header"
             >
-              <Flex
-                align="start"
-                dataTest=""
-                direction="row"
-                justify="spaceBetween"
+              <Section
+                bgColor="white"
+                border="bottom"
+                xPadding="default"
+                yPadding="default"
               >
-                <FlexItem
+                <Flex
+                  align="start"
                   dataTest=""
-                  shrink={false}
+                  direction="row"
+                  justify="spaceBetween"
                 >
-                  <div
-                    className="dialog-title type--head4"
-                    id="a11y-dialog-title"
+                  <FlexItem
+                    dataTest=""
+                    shrink={false}
                   >
-                    hey
-                  </div>
-                </FlexItem>
-                <FlexItem
-                  dataTest=""
-                  shrink={true}
-                >
-                  <button
-                    className="dialog-icon"
-                    onClick={[Function]}
+                    <div
+                      className="dialog-title type--head4"
+                      id="a11y-dialog-title"
+                    >
+                      hey
+                    </div>
+                  </FlexItem>
+                  <FlexItem
+                    dataTest=""
+                    shrink={true}
                   >
-                    <DenyIcon
-                      size="xs"
-                    />
-                  </button>
-                </FlexItem>
-              </Flex>
-            </Section>
-          </div>
-          <div
-            className="dialog-content"
-          >
-            <Section
-              bgColor="white"
-              xPadding="default"
-              yPadding="default"
+                    <button
+                      className="dialog-icon"
+                      onClick={[Function]}
+                    >
+                      <DenyIcon
+                        size="xs"
+                      />
+                    </button>
+                  </FlexItem>
+                </Flex>
+              </Section>
+            </div>
+            <div
+              className="dialog-content"
             >
-              foo
-            </Section>
-          </div>
-          <div
-            className="dialog-footer"
-          >
-            <Section
-              bgColor="white"
-              xPadding="default"
-              yPadding="default"
-            >
-              <div>
+              <Section
+                bgColor="white"
+                xPadding="default"
+                yPadding="default"
+              >
                 foo
-              </div>
-            </Section>
+              </Section>
+            </div>
+            <div
+              className="dialog-footer"
+            >
+              <Section
+                bgColor="white"
+                xPadding="default"
+                yPadding="default"
+              >
+                <div>
+                  foo
+                </div>
+              </Section>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/style/interactive/dialog.css
+++ b/src/components/style/interactive/dialog.css
@@ -27,11 +27,16 @@
   opacity: 0.3;
 }
 
+.dialog-wrapper {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 100vh;
+  align-items: center;
+}
+
 .dialog {
   position: fixed;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
   overflow: hidden;
   background-color: var(--color-white);
   border-radius: var(--border-radius-default);


### PR DESCRIPTION
## Description
Not sure why, but the current modal gets blurry when using transform to center position it. Went with an alternative centering method

## Screenshots
N/A

## Checklist
- [x] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [x] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**