### PR TITLE
127/popover/uip 486 hover mode focus issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,14 @@ This is an example of a brief overview of the _Major_ or _Minor_ version changes
 
 ---
 
+## [5.4] Update hover Popovers
+
+- In `Popover`, `focus` and `blur` events were replaced with `keyUp` and `keyDown` events.
+  This allows hover-triggered popovers to show the popover content on keyboard navigation
+  without side effects from focus events on the trigger itself.
+
 ## [5.3] Updated Button
+
 - Adjusted padding on small button
 
 ## [5.2] Update Buttons / Icons

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@
 * Jenkins populates the patch version depending on the branch.
 */
 
-String VERSION = "5.3"
+String VERSION = "5.4"
 
 /* ---- DO NOT EDIT BELOW (unless you really know what you're doing) ---- */
 

--- a/src/components/popovers/Popover.jsx
+++ b/src/components/popovers/Popover.jsx
@@ -40,8 +40,7 @@ const Popover = ({
   transitionName,
 }) => {
   const [isActive, setIsActive] = useState(false);
-  const [isFocused, setIsFocused] = useState(false);
-  const refTrigger = useRef(null);
+  const refTriggerWrap = useRef(null);
   let refContent = null; // must be assigned via setter fn in `Popper`
 
   // update active state on props change to accommodate fully controlled popovers
@@ -59,24 +58,11 @@ const Popover = ({
   };
 
   /**
-   * Closes popover when user is mousing over a non-popover element while the trigger
-   * is not focused.
-   * 🎶 function name should be sung to the tune of: https://youtu.be/LaTGrV58wec
-   * @param {Event} e DOMEvent
-   */
-  const handleBodyMouseMove = (e) => {
-    // in hover mode, only treat the trigger as the popover zone
-    const refs = interactionMode === 'hover' ? [refTrigger] : [refTrigger, refContent];
-    const isNotPopoverHover = isNotRefsEvent(refs, e);
-    if (!isFocused && isNotPopoverHover) setIsActive(false);
-  };
-
-  /**
    * Closes popover when user clicks outside of content or trigger
    * @param {Event} e DOMEvent
    */
   const handleBodyClick = (e) => {
-    const isNotPopoverClick = isNotRefsEvent([refTrigger, refContent], e);
+    const isNotPopoverClick = isNotRefsEvent([refTriggerWrap, refContent], e);
     if (isNotPopoverClick) setIsActive(false);
   };
 
@@ -85,17 +71,9 @@ const Popover = ({
     document.body.addEventListener('mousedown', handleBodyClick, false);
     document.body.addEventListener('keyup', handleKeyPress, false);
 
-    if (interactionMode === 'hover') {
-      document.body.addEventListener('mousemove', handleBodyMouseMove, false);
-    }
-
     return () => {
       document.body.removeEventListener('mousedown', handleBodyClick, false);
       document.body.removeEventListener('keyup', handleKeyPress, false);
-
-      if (interactionMode === 'hover') {
-        document.body.removeEventListener('mousemove', handleBodyMouseMove, false);
-      }
     };
     /* eslint-enable no-undef */
   });
@@ -106,13 +84,18 @@ const Popover = ({
       triggerProps.onMouseEnter = () => {
         setIsActive(true);
       };
-      triggerProps.onFocus = () => {
-        setIsActive(true);
-        setIsFocused(true);
-      };
-      triggerProps.onBlur = () => {
+      triggerProps.onMouseLeave = () => {
         setIsActive(false);
-        setIsFocused(false);
+      };
+      triggerProps.onKeyUp = (e) => {
+        if (e.key === 'Tab') {
+          setIsActive(true);
+        }
+      };
+      triggerProps.onKeyDown = (e) => {
+        if (e.key === 'Tab') {
+          setIsActive(false);
+        }
       };
       triggerProps.tabIndex = '1';
       break;
@@ -124,6 +107,8 @@ const Popover = ({
     default:
       triggerProps = {};
   }
+
+  const clonedTrigger = React.cloneElement(trigger, triggerProps);
 
   // https://popper.js.org/popper-documentation.html#modifiers
   const popperModifiers = {
@@ -183,9 +168,7 @@ const Popover = ({
       <Reference>
         {({ ref }) => (
           <div ref={ref} aria-haspopup="true" aria-expanded={isActive.toString()}>
-            <div ref={refTrigger} {...triggerProps}>
-              {trigger}
-            </div>
+            <div ref={refTriggerWrap}>{clonedTrigger}</div>
           </div>
         )}
       </Reference>

--- a/src/components/popovers/Tooltip.jsx
+++ b/src/components/popovers/Tooltip.jsx
@@ -9,7 +9,7 @@ const Tooltip = ({ trigger, message, maxWidth }) => (
   <Popover
     interactionMode="hover"
     trigger={<span style={{ cursor: 'help' }}>{trigger}</span>}
-    distance={FDS.SPACE_HALF}
+    distance={parseInt(FDS.SPACE_HALF, 10)}
     position="bottom"
     alignment="center"
     transitionName="GrowFast"

--- a/src/components/popovers/__snapshots__/popover.test.js.snap
+++ b/src/components/popovers/__snapshots__/popover.test.js.snap
@@ -6,7 +6,11 @@ exports[`Popover component matches snapshot (default props) 1`] = `
   distance={4}
   interactionMode="click"
   position="auto"
-  trigger={<Trigger />}
+  trigger={
+    <button>
+      trigger
+    </button>
+  }
 >
   <Manager>
     <Reference>
@@ -17,14 +21,12 @@ exports[`Popover component matches snapshot (default props) 1`] = `
           aria-expanded="false"
           aria-haspopup="true"
         >
-          <div
-            onClick={[Function]}
-          >
-            <Trigger>
-              <button>
-                trigger
-              </button>
-            </Trigger>
+          <div>
+            <button
+              onClick={[Function]}
+            >
+              trigger
+            </button>
           </div>
         </div>
       </InnerReference>

--- a/src/components/popovers/__snapshots__/tooltip.test.js.snap
+++ b/src/components/popovers/__snapshots__/tooltip.test.js.snap
@@ -7,7 +7,7 @@ exports[`Tooltip component matches snapshot (uses the right classes) 1`] = `
 >
   <Popover
     alignment="center"
-    distance="8px"
+    distance={8}
     interactionMode="hover"
     position="bottom"
     transitionName="GrowFast"

--- a/src/components/popovers/__snapshots__/tooltip.test.js.snap
+++ b/src/components/popovers/__snapshots__/tooltip.test.js.snap
@@ -32,18 +32,18 @@ exports[`Tooltip component matches snapshot (uses the right classes) 1`] = `
             aria-expanded="false"
             aria-haspopup="true"
           >
-            <div
-              onBlur={[Function]}
-              onFocus={[Function]}
-              onMouseEnter={[Function]}
-              tabIndex="1"
-            >
+            <div>
               <span
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                onMouseEnter={[Function]}
+                onMouseLeave={[Function]}
                 style={
                   Object {
                     "cursor": "help",
                   }
                 }
+                tabIndex="1"
               >
                 <Trigger>
                   <p>

--- a/src/components/popovers/popover.test.js
+++ b/src/components/popovers/popover.test.js
@@ -3,10 +3,10 @@ import { shallow, mount } from 'enzyme';
 
 import Popover, { getPopperPlacement } from './Popover';
 
-const Trigger = () => (<button>trigger</button>);
 const Content = () => (<p>popover content</p>);
+const triggerJsx = (<button>trigger</button>);
 
-const SELECTOR_TRIGGER = '[aria-haspopup] > div';
+const SELECTOR_TRIGGER = '[aria-haspopup] button';
 
 /**
  * @param {ReactWrapper} w enzyme react wrapper
@@ -17,24 +17,24 @@ const isPopperOpen = (w) => w.find('CSSTransition').prop('in');
 describe('Popover component', () => {
 
   it('matches snapshot (default props)', () => {
-    const wrapper = mount(<Popover trigger={<Trigger />}><Content /></Popover>);
+    const wrapper = mount(<Popover trigger={triggerJsx}><Content /></Popover>);
     expect(wrapper).toMatchSnapshot();
   });
 
   it('uses Portal by default', () => {
-    const wrapper = mount(<Popover trigger={<Trigger />}><Content /></Popover>);
+    const wrapper = mount(<Popover trigger={triggerJsx}><Content /></Popover>);
     expect(wrapper.exists('Portal')).toBe(true);
   });
 
   it('does NOT use Portal when disablePortal is set', () => {
-    const wrapper = mount(<Popover trigger={<Trigger />} disablePortal><Content /></Popover>);
+    const wrapper = mount(<Popover trigger={triggerJsx} disablePortal><Content /></Popover>);
     expect(wrapper.exists('Portal')).toBe(false);
   });
 
   it('ignores `isOpen` prop when not in controlled mode', () => {
     const wrapper = shallow(
       <Popover
-        trigger={<Trigger />}
+        trigger={triggerJsx}
         isOpen
       >
         <Content />
@@ -67,7 +67,7 @@ describe('Popover component', () => {
 
     beforeEach(() => {
       wrapper = mount(
-        <Popover trigger={<Trigger />} interactionMode="click">
+        <Popover trigger={triggerJsx} interactionMode="click">
           <Content />
         </Popover>
       );
@@ -107,7 +107,7 @@ describe('Popover component', () => {
 
     beforeEach(() => {
       wrapper = mount(
-        <Popover trigger={<Trigger />} interactionMode="hover">
+        <Popover trigger={triggerJsx} interactionMode="hover">
           <Content />
         </Popover>
       );
@@ -121,16 +121,16 @@ describe('Popover component', () => {
 
     it('adds hover-related props to trigger', () => {
       const triggerPropNames = Object.keys(triggerEl.props());
-      ['onMouseEnter', 'onFocus', 'onBlur', 'tabIndex'].forEach((prop) => {
+      ['onMouseEnter', 'onKeyUp', 'onKeyDown', 'tabIndex'].forEach((prop) => {
         expect(triggerPropNames).toContain(prop);
       });
     });
 
     it('opens and closes popover on focus/blur', () => {
       expect(isPopperOpen(wrapper)).toBe(false);
-      triggerEl.simulate('focus');
+      triggerEl.simulate('keyup', { key: 'Tab' });
       expect(isPopperOpen(wrapper)).toBe(true);
-      triggerEl.simulate('blur');
+      triggerEl.simulate('keydown', { key: 'Tab' });
       expect(isPopperOpen(wrapper)).toBe(false);
     });
 

--- a/src/components/popovers/popover.test.js
+++ b/src/components/popovers/popover.test.js
@@ -126,7 +126,7 @@ describe('Popover component', () => {
       });
     });
 
-    it('opens and closes popover on focus/blur', () => {
+    it('opens and closes popover on keyboard navigating in and out via Tab', () => {
       expect(isPopperOpen(wrapper)).toBe(false);
       triggerEl.simulate('keyup', { key: 'Tab' });
       expect(isPopperOpen(wrapper)).toBe(true);


### PR DESCRIPTION
## Description

- Remove `focus`/`blur` management from `Popover`
- Add `keyUp`/`keyDown` handlers to hover mode trigger to handle keyboard nav


## Checklist
- [x] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [x] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**

