### PR TITLE
[After Docblocks] UIP-494: storybook backgrounds

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -1,3 +1,4 @@
 import '@storybook/addon-knobs/register';
 import '@storybook/addon-notes/register-panel';
 import 'storybook-addon-react-docgen/register';
+import '@storybook/addon-backgrounds/register';

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -12,6 +12,10 @@ const theme = create({
 });
 
 addParameters({
+  backgrounds: [
+    { name: 'White', value: '#fff' },
+    { name: 'Navy', value: '#003366' },
+  ],
   options: {
     theme,
   },

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
   },
   "version": "4.0.0",
   "dependencies": {
+    "@storybook/addon-backgrounds": "^5.2.6",
     "focus-trap-react": "^6.0.0",
     "no-scroll": "^2.1.1",
     "raf-schd": "^4.0.2",

--- a/src/components/interactive/button.stories.mdx
+++ b/src/components/interactive/button.stories.mdx
@@ -30,39 +30,28 @@ export const iconOptions = options(
 Displays standard Buttons.
 
 <Story name="Knobs">
-  <div
-    className={
-      boolean("Toggle Background", false) ? "padding--all inverted" : ""
-    }
-    style={
-      boolean("Toggle Background", false)
-        ? { background: "var(--color-navy)" }
-        : {}
-    }
-  >
-    <Button
-      disabled={boolean("disabled", false)}
-      isLoading={boolean("isLoading", false)}
-      isDestructive={boolean("isDestructive", false)}
-      hasCaret={boolean("hasCaret", false)}
-      Icon={iconOptions ? StarFilledIcon : undefined}
-      iconPlacement={iconOptions}
-      isFullWidth={boolean("isFullWidth", false)}
-      size={options("size", arrayToOptions(["s", "m"]), undefined, {
+  <Button
+    disabled={boolean("disabled", false)}
+    isLoading={boolean("isLoading", false)}
+    isDestructive={boolean("isDestructive", false)}
+    hasCaret={boolean("hasCaret", false)}
+    Icon={iconOptions ? StarFilledIcon : undefined}
+    iconPlacement={iconOptions}
+    isFullWidth={boolean("isFullWidth", false)}
+    size={options("size", arrayToOptions(["s", "m"]), undefined, {
+      display: "inline-radio"
+    })}
+    theme={options(
+      "theme",
+      arrayToOptions(["blue", "outlined", "ghost"]),
+      undefined,
+      {
         display: "inline-radio"
-      })}
-      theme={options(
-        "theme",
-        arrayToOptions(["blue", "outlined", "ghost"]),
-        undefined,
-        {
-          display: "inline-radio"
-        }
-      )}
-    >
-      {text("Text", "Button")}
-    </Button>
-  </div>
+      }
+    )}
+  >
+    {text("Text", "Button")}
+  </Button>
 </Story>
 
 ## Handling events

--- a/src/components/interactive/iconButton.stories.js
+++ b/src/components/interactive/iconButton.stories.js
@@ -17,28 +17,21 @@ storiesOf('Interactive/IconButton', module)
   .add(
     'Knobs',
     () => (
-      <div
-        className={boolean('Toggle Background', false) ? 'padding--all inverted' : ''}
-        style={
-          boolean('Toggle Background', false) ? { background: 'var(--color-navy)' } : {}
-        }
-      >
-        <IconButton
-          isDestructive={boolean('isDestructive', false)}
-          disabled={boolean('disabled', false)}
-          isLoading={boolean('isLoading', false)}
-          theme={options('theme', arrayToOptions(['ghost', 'aqua']), undefined, {
-            display: 'inline-radio',
-          })}
-          size={options('size', arrayToOptions(['s', 'm']), undefined, {
-            display: 'inline-radio',
-          })}
-          radius={options('radius', arrayToOptions(['square', 'circle']), undefined, {
-            display: 'inline-radio',
-          })}
-          Icon={StarFilledIcon}
-        />
-      </div>
+      <IconButton
+        isDestructive={boolean('isDestructive', false)}
+        disabled={boolean('disabled', false)}
+        isLoading={boolean('isLoading', false)}
+        theme={options('theme', arrayToOptions(['ghost', 'aqua']), undefined, {
+          display: 'inline-radio',
+        })}
+        size={options('size', arrayToOptions(['s', 'm']), undefined, {
+          display: 'inline-radio',
+        })}
+        radius={options('radius', arrayToOptions(['square', 'circle']), undefined, {
+          display: 'inline-radio',
+        })}
+        Icon={StarFilledIcon}
+      />
     ),
     { notes: { markdown: README } }
   )

--- a/src/components/interactive/stackedButton.stories.js
+++ b/src/components/interactive/stackedButton.stories.js
@@ -17,19 +17,12 @@ storiesOf('Interactive/StackedButton', module)
   .add(
     'Knobs',
     () => (
-      <div
-        className={boolean('Toggle Background', false) ? 'padding--all inverted' : ''}
-        style={
-          boolean('Toggle Background', false) ? { background: 'var(--color-navy)' } : {}
-        }
-      >
-        <StackedButton
-          disabled={boolean('disabled', false)}
-          Icon={StarFilledIcon}
-          label={text('Text', 'Button')}
-          hasCaret={boolean('hasCaret', false)}
-        />
-      </div>
+      <StackedButton
+        disabled={boolean('disabled', false)}
+        Icon={StarFilledIcon}
+        label={text('Text', 'Button')}
+        hasCaret={boolean('hasCaret', false)}
+      />
     ),
     { notes: { markdown: README } }
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -65,7 +65,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.4.0", "@babel/generator@^7.6.2", "@babel/generator@^7.7.2":
+"@babel/generator@^7.4.0", "@babel/generator@^7.6.2", "@babel/generator@^7.6.3", "@babel/generator@^7.7.2":
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.7.2.tgz#2f4852d04131a5e17ea4f6645488b5da66ebf3af"
   integrity sha512-WthSArvAjYLz4TcbKOi88me+KmDJdKSlfwwN8CnUYn9jBkzhq0ZEPuBfkAWIvjJ3AdEV1Cf/+eSQTnp3IDJKlQ==
@@ -144,7 +144,7 @@
     "@babel/traverse" "^7.7.0"
     "@babel/types" "^7.7.0"
 
-"@babel/helper-function-name@^7.7.0":
+"@babel/helper-function-name@^7.1.0", "@babel/helper-function-name@^7.7.0":
   version "7.7.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.7.0.tgz#44a5ad151cfff8ed2599c91682dda2ec2c8430a3"
   integrity sha512-tDsJgMUAP00Ugv8O2aGEua5I2apkaQO7lBGUq1ocwN3G23JE5Dcq0uh3GvFTChPa4b40AWiAsLvCZOA2rdnQ7Q==
@@ -241,7 +241,7 @@
     "@babel/template" "^7.7.0"
     "@babel/types" "^7.7.0"
 
-"@babel/helper-split-export-declaration@^7.7.0":
+"@babel/helper-split-export-declaration@^7.4.4", "@babel/helper-split-export-declaration@^7.7.0":
   version "7.7.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.0.tgz#1365e74ea6c614deeb56ebffabd71006a0eb2300"
   integrity sha512-HgYSI8rH08neWlAH3CcdkFg9qX9YsZysZI5GD8LjhQib/mM0jGOZOVkoUiiV2Hu978fRtjtsGsW6w0pKHUWtqA==
@@ -285,7 +285,7 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.2.3", "@babel/parser@^7.4.2", "@babel/parser@^7.4.3", "@babel/parser@^7.6.2", "@babel/parser@^7.7.0", "@babel/parser@^7.7.2":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.2.3", "@babel/parser@^7.4.2", "@babel/parser@^7.4.3", "@babel/parser@^7.6.2", "@babel/parser@^7.6.3", "@babel/parser@^7.7.0", "@babel/parser@^7.7.2":
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.3.tgz#5fad457c2529de476a248f75b0f090b3060af043"
   integrity sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==
@@ -817,7 +817,7 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
-"@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.6.0", "@babel/types@^7.7.0", "@babel/types@^7.7.1", "@babel/types@^7.7.2":
+"@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.4.4", "@babel/types@^7.6.0", "@babel/types@^7.6.3", "@babel/types@^7.7.0", "@babel/types@^7.7.1", "@babel/types@^7.7.2":
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.7.2.tgz#550b82e5571dcd174af576e23f0adba7ffc683f7"
   integrity sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==
@@ -1203,6 +1203,22 @@
     react-inspector "^4.0.0"
     uuid "^3.3.2"
 
+"@storybook/addon-backgrounds@^5.2.6":
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/@storybook/addon-backgrounds/-/addon-backgrounds-5.2.6.tgz#c35f009f2a831ee871bc143f1be1568df45cc01d"
+  integrity sha512-bEhRgYU7nV8w2rBEvPIgcRblrp6RP8DMFahJGjTNlIzGfQjge+C1gKN751ghE8UhZuf82tO2OE3rijDu4Kb9WA==
+  dependencies:
+    "@storybook/addons" "5.2.6"
+    "@storybook/api" "5.2.6"
+    "@storybook/client-logger" "5.2.6"
+    "@storybook/components" "5.2.6"
+    "@storybook/core-events" "5.2.6"
+    "@storybook/theming" "5.2.6"
+    core-js "^3.0.1"
+    memoizerific "^1.11.3"
+    react "^16.8.3"
+    util-deprecate "^1.0.2"
+
 "@storybook/addon-centered@^5.2.3":
   version "5.2.6"
   resolved "https://registry.yarnpkg.com/@storybook/addon-centered/-/addon-centered-5.2.6.tgz#34fa4674e5b669bbac4050cf45e4c01acb0f4660"
@@ -1439,6 +1455,31 @@
   integrity sha512-raHyV8z3DjYoan90B4gnUCsp2nA43u4qx/qm5/3rOLCsGE6gIvRi1UV5FN7CyWu2p8NqoLxSU7uhENieG0GgyQ==
   dependencies:
     core-js "^3.0.1"
+
+"@storybook/components@5.2.6":
+  version "5.2.6"
+  resolved "https://registry.yarnpkg.com/@storybook/components/-/components-5.2.6.tgz#cddb60227720aea7cae34fe782d0370bcdbd4005"
+  integrity sha512-C7OS90bZ1ZvxlWUZ3B2MPFFggqAtUo7X8DqqS3IwsuDUiK9dD/KS0MwPgOuFDnOTW1R5XqmQd/ylt53w3s/U5g==
+  dependencies:
+    "@storybook/client-logger" "5.2.6"
+    "@storybook/theming" "5.2.6"
+    "@types/react-syntax-highlighter" "10.1.0"
+    "@types/react-textarea-autosize" "^4.3.3"
+    core-js "^3.0.1"
+    global "^4.3.2"
+    markdown-to-jsx "^6.9.1"
+    memoizerific "^1.11.3"
+    polished "^3.3.1"
+    popper.js "^1.14.7"
+    prop-types "^15.7.2"
+    react "^16.8.3"
+    react-dom "^16.8.3"
+    react-focus-lock "^1.18.3"
+    react-helmet-async "^1.0.2"
+    react-popper-tooltip "^2.8.3"
+    react-syntax-highlighter "^8.0.1"
+    react-textarea-autosize "^7.1.0"
+    simplebar-react "^1.0.0-alpha.6"
 
 "@storybook/components@5.3.0-beta.3":
   version "5.3.0-beta.3"
@@ -1956,6 +1997,13 @@
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@types/react-color/-/react-color-3.0.1.tgz#5433e2f503ea0e0831cbc6fd0c20f8157d93add0"
   integrity sha512-J6mYm43Sid9y+OjZ7NDfJ2VVkeeuTPNVImNFITgQNXodHteKfl/t/5pAR5Z9buodZ2tCctsZjgiMlQOpfntakw==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-syntax-highlighter@10.1.0":
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/@types/react-syntax-highlighter/-/react-syntax-highlighter-10.1.0.tgz#9c534e29bbe05dba9beae1234f3ae944836685d4"
+  integrity sha512-dF49hC4FZp1dIKyzacOrHvqMUe8U2IXyQCQXOcT1e6n64gLBp+xM6qGtPsThIT9XjiIHSg2W5Jc2V5IqekBfnA==
   dependencies:
     "@types/react" "*"
 
@@ -3014,7 +3062,7 @@ babel-preset-jest@^24.9.0:
     babel-plugin-transform-undefined-to-void "^6.9.4"
     lodash "^4.17.11"
 
-babel-runtime@^6.26.0:
+babel-runtime@^6.18.0, babel-runtime@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   integrity sha1-llxwWGaOgrVde/4E/yM3vItWR/4=
@@ -5614,7 +5662,7 @@ fn-name@~2.0.1:
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
   integrity sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
 
-focus-lock@^0.6.6:
+focus-lock@^0.6.3, focus-lock@^0.6.6:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.6.tgz#98119a755a38cfdbeda0280eaa77e307eee850c7"
   integrity sha512-Dx69IXGCq1qsUExWuG+5wkiMqVM/zGx/reXSJSLogECwp3x6KeNQZ+NAetgxEFpnC41rD8U3+jRCW68+LNzdtw==
@@ -6249,6 +6297,11 @@ hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
+
+highlight.js@~9.12.0:
+  version "9.12.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
+  integrity sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4=
 
 highlight.js@~9.13.0:
   version "9.13.1"
@@ -8067,6 +8120,14 @@ lowlight@~1.11.0:
   dependencies:
     fault "^1.0.2"
     highlight.js "~9.13.0"
+
+lowlight@~1.9.1:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/lowlight/-/lowlight-1.9.2.tgz#0b9127e3cec2c3021b7795dd81005c709a42fdd1"
+  integrity sha512-Ek18ElVCf/wF/jEm1b92gTnigh94CtBNWiZ2ad+vTgW7cTmQxUY3I98BjHK68gZAJEWmybGBZgx9qv3QxLQB/Q==
+  dependencies:
+    fault "^1.0.2"
+    highlight.js "~9.12.0"
 
 lru-cache@^4.1.5:
   version "4.1.5"
@@ -10749,7 +10810,7 @@ react-addons-create-fragment@^15.6.2:
     loose-envify "^1.3.1"
     object-assign "^4.1.0"
 
-react-clientside-effect@^1.2.2:
+react-clientside-effect@^1.2.0, react-clientside-effect@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz#6212fb0e07b204e714581dd51992603d1accc837"
   integrity sha512-nRmoyxeok5PBO6ytPvSjKp9xwXg9xagoTK1mMjwnQxqM9Hd7MNPl+LS1bOSOe+CV2+4fnEquc7H/S8QD3q697A==
@@ -10840,6 +10901,16 @@ react-fast-compare@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
+
+react-focus-lock@^1.18.3:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-1.19.1.tgz#2f3429793edaefe2d077121f973ce5a3c7a0651a"
+  integrity sha512-TPpfiack1/nF4uttySfpxPk4rGZTLXlaZl7ncZg/ELAk24Iq2B1UUaUioID8H8dneUXqznT83JTNDHDj+kwryw==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    focus-lock "^0.6.3"
+    prop-types "^15.6.2"
+    react-clientside-effect "^1.2.0"
 
 react-focus-lock@^2.1.0:
   version "2.2.1"
@@ -10955,6 +11026,17 @@ react-syntax-highlighter@^11.0.2:
     "@babel/runtime" "^7.3.1"
     highlight.js "~9.13.0"
     lowlight "~1.11.0"
+    prismjs "^1.8.4"
+    refractor "^2.4.1"
+
+react-syntax-highlighter@^8.0.1:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-8.1.0.tgz#59103ff17a828a27ed7c8f035ae2558f09b6b78c"
+  integrity sha512-G2bkZxmF3VOa4atEdXIDSfwwCqjw6ZQX5znfTaHcErA1WqHIS0o6DaSCDKFPVaOMXQEB9Hf1UySYQvuJmV8CXg==
+  dependencies:
+    babel-runtime "^6.18.0"
+    highlight.js "~9.12.0"
+    lowlight "~1.9.1"
     prismjs "^1.8.4"
     refractor "^2.4.1"
 


### PR DESCRIPTION
## Description
Add support to trigger backgrounds & grid effect on any story (going to start with just white and navy, and we can add if designers are interested)

I removed all the knobs related to toggling these backgrounds on specific stories, as they were no longer needed with this new feature.

This uses docblocks and should 100% come after that's merged into master.

## Screenshots
<img width="1166" alt="Screen Shot 2019-11-22 at 1 37 46 PM" src="https://user-images.githubusercontent.com/52427513/69451409-4a551200-0d2d-11ea-9eb6-b662aa0514c5.png">


## Checklist
- [x] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [x] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**