### PR TITLE
UIP-555: Use IconButton in Modal iconbutton

### DIFF
--- a/src/components/interactive/IconButton.jsx
+++ b/src/components/interactive/IconButton.jsx
@@ -41,6 +41,7 @@ const IconButton = ({
         }
       )}
       disabled={disabled && Element === 'button'}
+      role="img"
     >
       <span className={isLoading ? 'fdsIconButton--hidden' : ''}>
         <Icon customSize={size === 's' ? 16 : 18} />

--- a/src/components/interactive/__snapshots__/iconButton.test.js.snap
+++ b/src/components/interactive/__snapshots__/iconButton.test.js.snap
@@ -3,6 +3,7 @@
 exports[`ButtonGroup component matches snapshot (default props) 1`] = `
 <button
   className="fdsIconButton rounded--all border--focus--noTransition transition-default fdsIconButton--ghost fdsIconButton--m"
+  role="img"
 >
   <span
     className=""
@@ -18,6 +19,7 @@ exports[`ButtonGroup component matches snapshot (set all props) 1`] = `
 <button
   className="fdsIconButton rounded--all border--focus--noTransition transition-default fdsIconButton--aqua fdsIconButton--s fdsIconButton--disabled fdsIconButton--active fdsIconButton--circle fdsIconButton--isDestructive fdsIconButton--loading"
   disabled={true}
+  role="img"
 >
   <span
     className="fdsIconButton--hidden"

--- a/src/components/modals/Dialog.jsx
+++ b/src/components/modals/Dialog.jsx
@@ -6,8 +6,7 @@ import FocusTrap from 'focus-trap-react';
 import noScroll from 'no-scroll';
 import rafSchd from 'raf-schd';
 import DenyIcon from '../../../lib/icons/react/DenyIcon';
-import Flex from '../layout/Flex';
-import FlexItem from '../layout/FlexItem';
+import IconButton from '../interactive/IconButton';
 import Section from '../layout/Section';
 
 export const isElementOverflowing = ({ current }) => {
@@ -76,25 +75,19 @@ const Dialog = (props) => {
                   <React.Fragment>
                     <div className="dialog-header">
                       <Section border="bottom">
-                        <Flex justify="spaceBetween" align="start">
-                          <FlexItem>
-                            {props.title && (
-                              <div
-                                className="dialog-title type--head4"
-                                id="a11y-dialog-title"
-                              >
-                                {props.title}
-                              </div>
-                            )}
-                          </FlexItem>
-                          {props.onDismiss && (
-                            <FlexItem shrink>
-                              <button className="dialog-icon" onClick={props.onDismiss}>
-                                <DenyIcon size="xs" />
-                              </button>
-                            </FlexItem>
-                          )}
-                        </Flex>
+                        <div className="padding--right--double type--head4">
+                          {props.title ? (
+                            <span id="a11y-dialog-title">{props.title}</span>
+                          ) : (
+                            '\u00A0'
+                          )}{' '}
+                          {/* There always needs to be something (even a space) in the header for display reasons */}
+                        </div>
+                        {props.onDismiss && (
+                          <div className="dialog-icon">
+                            <IconButton Icon={DenyIcon} onClick={props.onDismiss} />
+                          </div>
+                        )}
                       </Section>
                     </div>
                   </React.Fragment>

--- a/src/components/modals/Dialog.jsx
+++ b/src/components/modals/Dialog.jsx
@@ -85,7 +85,11 @@ const Dialog = (props) => {
                         </div>
                         {props.onDismiss && (
                           <div className="dialog-icon">
-                            <IconButton Icon={DenyIcon} onClick={props.onDismiss} />
+                            <IconButton
+                              Icon={DenyIcon}
+                              onClick={props.onDismiss}
+                              aria-label="close"
+                            />
                           </div>
                         )}
                       </Section>

--- a/src/components/modals/__snapshots__/dialog.test.js.snap
+++ b/src/components/modals/__snapshots__/dialog.test.js.snap
@@ -26,19 +26,25 @@ exports[`Dialog component matches snapshot (default props) 1`] = `
                 class="bgColor--white display--block padding--left padding--right padding--top padding--bottom border--bottom"
               >
                 <div
-                  class="flex flex--alignStart flex--row flex--justifySpaceBetween"
+                  class="padding--right--double type--head4"
                 >
-                  <div
-                    class="flexItem"
-                  />
-                  <div
-                    class="flexItem flexItem--shrink"
+                   
+                   
+                </div>
+                <div
+                  class="dialog-icon"
+                >
+                  <button
+                    aria-label="close"
+                    class="fdsIconButton rounded--all border--focus--noTransition transition-default fdsIconButton--ghost fdsIconButton--m"
+                    role="img"
                   >
-                    <button
-                      class="dialog-icon"
+                    <span
+                      class=""
                     >
                       <div
-                        class="fds-icon fds-icon--xs"
+                        class="fds-icon fds-icon--s"
+                        style="width: 18px; height: 18px;"
                       >
                         <svg
                           viewBox="0 0 24 24"
@@ -54,8 +60,8 @@ exports[`Dialog component matches snapshot (default props) 1`] = `
                           </g>
                         </svg>
                       </div>
-                    </button>
-                  </div>
+                    </span>
+                  </button>
                 </div>
               </div>
             </div>
@@ -95,19 +101,25 @@ exports[`Dialog component matches snapshot (default props) 1`] = `
                 class="bgColor--white display--block padding--left padding--right padding--top padding--bottom border--bottom"
               >
                 <div
-                  class="flex flex--alignStart flex--row flex--justifySpaceBetween"
+                  class="padding--right--double type--head4"
                 >
-                  <div
-                    class="flexItem"
-                  />
-                  <div
-                    class="flexItem flexItem--shrink"
+                   
+                   
+                </div>
+                <div
+                  class="dialog-icon"
+                >
+                  <button
+                    aria-label="close"
+                    class="fdsIconButton rounded--all border--focus--noTransition transition-default fdsIconButton--ghost fdsIconButton--m"
+                    role="img"
                   >
-                    <button
-                      class="dialog-icon"
+                    <span
+                      class=""
                     >
                       <div
-                        class="fds-icon fds-icon--xs"
+                        class="fds-icon fds-icon--s"
+                        style="width: 18px; height: 18px;"
                       >
                         <svg
                           viewBox="0 0 24 24"
@@ -123,8 +135,8 @@ exports[`Dialog component matches snapshot (default props) 1`] = `
                           </g>
                         </svg>
                       </div>
-                    </button>
-                  </div>
+                    </span>
+                  </button>
                 </div>
               </div>
             </div>
@@ -251,19 +263,25 @@ exports[`Dialog component matches snapshot (set all props) 1`] = `
                 class="bgColor--white display--block padding--left padding--right padding--top padding--bottom border--bottom"
               >
                 <div
-                  class="flex flex--alignStart flex--row flex--justifySpaceBetween"
+                  class="padding--right--double type--head4"
                 >
-                  <div
-                    class="flexItem"
-                  />
-                  <div
-                    class="flexItem flexItem--shrink"
+                   
+                   
+                </div>
+                <div
+                  class="dialog-icon"
+                >
+                  <button
+                    aria-label="close"
+                    class="fdsIconButton rounded--all border--focus--noTransition transition-default fdsIconButton--ghost fdsIconButton--m"
+                    role="img"
                   >
-                    <button
-                      class="dialog-icon"
+                    <span
+                      class=""
                     >
                       <div
-                        class="fds-icon fds-icon--xs"
+                        class="fds-icon fds-icon--s"
+                        style="width: 18px; height: 18px;"
                       >
                         <svg
                           viewBox="0 0 24 24"
@@ -279,8 +297,8 @@ exports[`Dialog component matches snapshot (set all props) 1`] = `
                           </g>
                         </svg>
                       </div>
-                    </button>
-                  </div>
+                    </span>
+                  </button>
                 </div>
               </div>
             </div>
@@ -320,19 +338,25 @@ exports[`Dialog component matches snapshot (set all props) 1`] = `
                 class="bgColor--white display--block padding--left padding--right padding--top padding--bottom border--bottom"
               >
                 <div
-                  class="flex flex--alignStart flex--row flex--justifySpaceBetween"
+                  class="padding--right--double type--head4"
                 >
-                  <div
-                    class="flexItem"
-                  />
-                  <div
-                    class="flexItem flexItem--shrink"
+                   
+                   
+                </div>
+                <div
+                  class="dialog-icon"
+                >
+                  <button
+                    aria-label="close"
+                    class="fdsIconButton rounded--all border--focus--noTransition transition-default fdsIconButton--ghost fdsIconButton--m"
+                    role="img"
                   >
-                    <button
-                      class="dialog-icon"
+                    <span
+                      class=""
                     >
                       <div
-                        class="fds-icon fds-icon--xs"
+                        class="fds-icon fds-icon--s"
+                        style="width: 18px; height: 18px;"
                       >
                         <svg
                           viewBox="0 0 24 24"
@@ -348,8 +372,8 @@ exports[`Dialog component matches snapshot (set all props) 1`] = `
                           </g>
                         </svg>
                       </div>
-                    </button>
-                  </div>
+                    </span>
+                  </button>
                 </div>
               </div>
             </div>
@@ -441,34 +465,28 @@ exports[`Dialog component matches snapshot (set all props) 1`] = `
                 xPadding="default"
                 yPadding="default"
               >
-                <Flex
-                  align="start"
-                  direction="row"
-                  justify="spaceBetween"
+                <div
+                  className="padding--right--double type--head4"
                 >
-                  <FlexItem
-                    shrink={false}
+                  <span
+                    id="a11y-dialog-title"
                   >
-                    <div
-                      className="dialog-title type--head4"
-                      id="a11y-dialog-title"
-                    >
-                      hey
-                    </div>
-                  </FlexItem>
-                  <FlexItem
-                    shrink={true}
-                  >
-                    <button
-                      className="dialog-icon"
-                      onClick={[Function]}
-                    >
-                      <DenyIcon
-                        size="xs"
-                      />
-                    </button>
-                  </FlexItem>
-                </Flex>
+                    hey
+                  </span>
+                   
+                </div>
+                <div
+                  className="dialog-icon"
+                >
+                  <IconButton
+                    Icon={[Function]}
+                    aria-label="close"
+                    onClick={[Function]}
+                    radius="square"
+                    size="m"
+                    theme="ghost"
+                  />
+                </div>
               </Section>
             </div>
             <div

--- a/src/components/modals/dialog.test.js
+++ b/src/components/modals/dialog.test.js
@@ -7,7 +7,7 @@ describe('Dialog component', () => {
   it('dismisses modal when close icon is clicked', () => {
     const dismissFn = jest.fn()
     const wrapper = mount(<Dialog isOpen={true} onDismiss={dismissFn} content={<button>hey</button>} />);
-    wrapper.find('.dialog-icon').prop('onClick')();
+    wrapper.find('IconButton').prop('onClick')();
     expect(dismissFn).toHaveBeenCalled();
   });
 

--- a/src/components/style/modals/dialog.css
+++ b/src/components/style/modals/dialog.css
@@ -4,6 +4,10 @@
   position: relative;
 }
 
+.dialog-header {
+  position: relative;
+}
+
 .dialog-enter-active {
   opacity: 1;
   transition: opacity 200ms;
@@ -77,8 +81,7 @@
 }
 
 .dialog-icon {
-  background-color: transparent;
-  cursor: pointer;
-  border: 0 none;
-  min-height: auto;
+  position: absolute;
+  top: 12px;
+  right: 12px;
 }


### PR DESCRIPTION
## Description
<!-- Enter a brief description of your changes -->

## Screenshots
<img width="528" alt="Screen Shot 2020-01-08 at 3 52 00 PM" src="https://user-images.githubusercontent.com/52427513/72014970-e3cd7a00-322e-11ea-88e6-bc0701f50875.png">

We're currently not using IconButton in modal for the close button. Let's make it happen!

## Checklist
- [x] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [x] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**