### PR TITLE
UIP-569: Added caret examples to button stories

### DIFF
--- a/src/components/interactive/button.stories.mdx
+++ b/src/components/interactive/button.stories.mdx
@@ -13,11 +13,7 @@ import ButtonGroup from "./ButtonGroup";
 
 export const iconOptions = options(
   "Show sample icon?",
-  {
-    left: "left",
-    right: "right",
-    none: null
-  },
+  arrayToOptions(ICON_PLACEMENTS),
   undefined,
   { display: "inline-radio" }
 );
@@ -125,7 +121,7 @@ Modifies the theme. Should only be used when the interaction involves data loss,
 
 ### Icons
 
-Only should pass in FDS Icon references (refer to code sample)
+ONLY pass in FDS Icon references to `Icon`. Very important. (refer to code sample)
 
 <Preview>
   <Story name="Icons">
@@ -139,24 +135,41 @@ Only should pass in FDS Icon references (refer to code sample)
   </Story>
 </Preview>
 
-### Misc
+### Caret
 
 <Preview>
-  <Story name="Misc">
+  <Story name="Caret">
     <div>
-      <div
-        className="margin--right--half margin--bottom--half display--inlineBlock"
-        style={{ width: '100px' }}
-      >
-        <Button>
-          Text can wrap
-        </Button>
-      </div>
       <div className="margin--right--half margin--bottom--half display--inlineBlock">
         <Button theme="blue" hasCaret>
           Caret
         </Button>
       </div>
+      <div className="margin--right--half margin--bottom--half display--inlineBlock">
+        <Button theme="blue" iconPlacement="left" hasCaret  Icon={StarFilledIcon}>
+          Caret
+        </Button>
+      </div>
+      <div className="margin--right--half margin--bottom--half display--inlineBlock">
+        <Button theme="blue" iconPlacement="right" hasCaret  Icon={StarFilledIcon}>
+          Caret
+        </Button>
+      </div>
+    </div>
+  </Story>
+</Preview>
+
+### Misc
+
+<Preview>
+  <Story name="Misc">
+    <div
+      className="margin--right--half margin--bottom--half display--inlineBlock"
+      style={{ width: '100px' }}
+    >
+      <Button>
+        Text can wrap
+      </Button>
     </div>
   </Story>
 </Preview>


### PR DESCRIPTION
## Description
- added a section specifically for caret
- add arrayToOptions for knobs
- made certain documentation more urgent

## Screenshots
<img width="448" alt="Screen Shot 2020-01-15 at 11 45 35 AM" src="https://user-images.githubusercontent.com/52427513/72453092-92703e00-378c-11ea-8c4c-880492b447d3.png">

## Checklist
- [x] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [x] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**