### PR TITLE
UIP-572: Button accepts label instead of children now

### DIFF
--- a/src/components/interactive/Button.jsx
+++ b/src/components/interactive/Button.jsx
@@ -15,7 +15,7 @@ const Button = ({
   Link,
   size,
   disabled,
-  children,
+  label,
   isLoading,
   isDestructive,
   isFullWidth,
@@ -50,7 +50,7 @@ const Button = ({
       disabled={disabled && Element === 'button'}
     >
       <span className={cx('fdsButton-label', { 'fdsButton--hidden': isLoading })}>
-        {children}
+        {label}
       </span>
       {Icon && (
         <div
@@ -79,6 +79,37 @@ Button.defaultProps = {
 };
 
 Button.propTypes = {
+  /** Text inside the button */
+  label: PropTypes.string.isRequired,
+  /** Used to control the display and theme of the button */
+  theme: PropTypes.oneOf(THEMES),
+  /** Used to control the size of the button */
+  /**
+   * Controls whether button should be in a destructive UI state.
+   * This only influences UI, there is no functional differences enabled
+   * with this boolean
+   */
+  isDestructive: PropTypes.bool,
+  size: PropTypes.oneOf(SIZES),
+  /**  Pass in "only" a FDS Icon reference to display it (e.g. Icon={ApproveIcon}) */
+  Icon: PropTypes.func,
+  /** Controls side the `Icon` renders on */
+  iconPlacement: PropTypes.oneOf(ICON_PLACEMENTS),
+  /** Controls showing CaretDown icon (right aligned) */
+  hasCaret: PropTypes.bool,
+  /**
+   * Controls whether the button is disabled or not. Will control the disabled
+   * presentation of either an anchor or button rendered under the hood,
+   * but will only add a disabled attribute for buttons
+   */
+  disabled: PropTypes.bool,
+  /** Controls the button going full width */
+  isFullWidth: PropTypes.bool,
+  /**
+   * Controls whether loading spinner displays. Button text and icons are set to visibility hidden
+   * to preserve the space set, whilst hiding them
+   */
+  isLoading: PropTypes.bool,
   /**
    * Takes in a react-router `Link` reference and sets it
    * as the base element. You may ONLY use it like the
@@ -88,37 +119,6 @@ Button.propTypes = {
    * - `Link={Link}`
    */
   Link: PropTypes.func,
-  /**
-   * Controls whether loading spinner displays. Button text and icons are set to visibility hidden
-   * to preserve the space set, whilst hiding them
-   */
-  isLoading: PropTypes.bool,
-  /**
-   * Controls whether button should be in a destructive UI state.
-   * This only influences UI, there is no functional differences enabled
-   * with this boolean
-   */
-  isDestructive: PropTypes.bool,
-  /**
-   * Controls whether the button is disabled or not. Will control the disabled
-   * presentation of either an anchor or button rendered under the hood,
-   * but will only add a disabled attribute for buttons
-   */
-  disabled: PropTypes.bool,
-  /** Controls which side the `Icon` renders on, assuming you pass it */
-  iconPlacement: PropTypes.oneOf(ICON_PLACEMENTS),
-  /**  Pass in "only" a FDS Icon reference to display it (e.g. Icon={ApproveIcon}) */
-  Icon: PropTypes.func,
-  /** Controls the button going full width */
-  isFullWidth: PropTypes.bool,
-  /** Controls showing CaretDown icon (right aligned) */
-  hasCaret: PropTypes.bool,
-  /** Used to control the display and theme of the button */
-  theme: PropTypes.oneOf(THEMES),
-  /** Used to control the size of the button */
-  size: PropTypes.oneOf(SIZES),
-  /** Contents inside the button */
-  children: PropTypes.node,
 };
 
 export default Button;

--- a/src/components/interactive/Toast.jsx
+++ b/src/components/interactive/Toast.jsx
@@ -87,9 +87,12 @@ const Toast = ({
           {actionLabel && onAction && (
             <FlexItem shrink>
               <div className="toast-constrainGrowth alignChild--center--center">
-                <Button onClick={onActionDismiss} data-test="toast-action" theme="ghost">
-                  {actionLabel}
-                </Button>
+                <Button
+                  onClick={onActionDismiss}
+                  data-test="toast-action"
+                  theme="ghost"
+                  label={actionLabel}
+                />
               </div>
             </FlexItem>
           )}

--- a/src/components/interactive/__snapshots__/button.test.js.snap
+++ b/src/components/interactive/__snapshots__/button.test.js.snap
@@ -19,7 +19,9 @@ exports[`ButtonGroup component matches snapshot (set all props) 1`] = `
 >
   <span
     className="fdsButton-label fdsButton--hidden"
-  />
+  >
+    Button
+  </span>
   <div
     className="alignChild--center--center fdsButton-icon--left fdsButton--hidden"
   >

--- a/src/components/interactive/__snapshots__/stackedButton.test.js.snap
+++ b/src/components/interactive/__snapshots__/stackedButton.test.js.snap
@@ -1,32 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ButtonGroup component matches snapshot (default props) 1`] = `
+exports[`StackedButton component matches snapshot (default props) 1`] = `
 <button
-  className="fdsButton fontStyle--caps display--inlineFlex rounded--all alignChild--center--center border--focus--noTransition transition--default fdsButton--m fdsButton--blue"
-  label="Button"
+  className="fdsStackedButton rounded--all fdsStackedButton--ghost border--focus--noTransition transition--default"
 >
-  <span
-    className="fdsButton-label"
-  />
+  Button
 </button>
 `;
 
-exports[`ButtonGroup component matches snapshot (set all props) 1`] = `
+exports[`StackedButton component matches snapshot (set all props) 1`] = `
 <Link
-  className="fdsButton fontStyle--caps display--inlineFlex rounded--all alignChild--center--center border--focus--noTransition transition--default fdsButton--m fdsButton--blue fdsButton--disabled"
+  className="fdsStackedButton rounded--all fdsStackedButton--ghost border--focus--noTransition transition--default fdsStackedButton--disabled fdsStackedButton--active"
   disabled={false}
-  isActive={true}
-  label="button"
 >
-  <span
-    className="fdsButton-label"
-  />
   <div
-    className="alignChild--center--center fdsButton-icon--right"
+    className="fdsStackedButton-iconWrapper"
   >
     <Icon
-      customSize={18}
+      size="xs"
     />
   </div>
+  button
 </Link>
 `;

--- a/src/components/interactive/button.stories.mdx
+++ b/src/components/interactive/button.stories.mdx
@@ -26,6 +26,7 @@ Displays standard Buttons.
 
 <Story name="Knobs">
   <Button
+    label={text("Text", "Button")}
     disabled={boolean("disabled", false)}
     isLoading={boolean("isLoading", false)}
     isDestructive={boolean("isDestructive", false)}
@@ -44,9 +45,7 @@ Displays standard Buttons.
         display: "inline-radio"
       }
     )}
-  >
-    {text("Text", "Button")}
-  </Button>
+  />
 </Story>
 
 <Props of={Button} />
@@ -60,9 +59,8 @@ Displays standard Buttons.
       <StoryItem>
         <Button
           theme={theme}
-        >
-          {theme} 
-        </Button>
+          label={theme}
+        />
       </StoryItem>
     ))}
     </StoryWrapper>
@@ -81,9 +79,8 @@ Modifies the theme. Should only be used when the interaction involves data loss,
         <Button
           theme={theme}
           isDestructive
-        >
-          {theme} 
-        </Button>
+          label={theme}
+        />
       </StoryItem>
     ))}
     </StoryWrapper>
@@ -98,9 +95,8 @@ Modifies the theme. Should only be used when the interaction involves data loss,
       <div className="display--inlineBlock margin--right--half margin--bottom--half">
         <Button
           size={size}
-        >
-          size: {size} 
-        </Button>
+          label={`Button (${size})`}
+        />
       </div>
     ))}
   </Story>
@@ -113,9 +109,8 @@ Modifies the theme. Should only be used when the interaction involves data loss,
   <Story name="Full Width">
     <Button
       isFullWidth
-    >
-      Button
-    </Button>
+      label="Button"
+    />
   </Story>
 </Preview>
 
@@ -127,9 +122,7 @@ ONLY pass in FDS Icon references to `Icon`. Very important. (refer to code sampl
   <Story name="Icons">
     {ICON_PLACEMENTS.map(placement => (
       <div className="margin--right--half margin--bottom--half display--inlineBlock">
-        <Button Icon={StarFilledIcon} iconPlacement={placement}>
-          Button
-        </Button>
+        <Button Icon={StarFilledIcon} iconPlacement={placement} label="Button" />
       </div>
     ))}
   </Story>
@@ -141,19 +134,13 @@ ONLY pass in FDS Icon references to `Icon`. Very important. (refer to code sampl
   <Story name="Caret">
     <div>
       <div className="margin--right--half margin--bottom--half display--inlineBlock">
-        <Button theme="blue" hasCaret>
-          Caret
-        </Button>
+        <Button theme="blue" hasCaret label="Caret" />
       </div>
       <div className="margin--right--half margin--bottom--half display--inlineBlock">
-        <Button theme="blue" iconPlacement="left" hasCaret  Icon={StarFilledIcon}>
-          Caret
-        </Button>
+        <Button theme="blue" iconPlacement="left" hasCaret  Icon={StarFilledIcon} label="Caret" />
       </div>
       <div className="margin--right--half margin--bottom--half display--inlineBlock">
-        <Button theme="blue" iconPlacement="right" hasCaret  Icon={StarFilledIcon}>
-          Caret
-        </Button>
+        <Button theme="blue" iconPlacement="right" hasCaret  Icon={StarFilledIcon} label="Caret" />
       </div>
     </div>
   </Story>
@@ -167,9 +154,7 @@ ONLY pass in FDS Icon references to `Icon`. Very important. (refer to code sampl
       className="margin--right--half margin--bottom--half display--inlineBlock"
       style={{ width: '100px' }}
     >
-      <Button>
-        Text can wrap
-      </Button>
+      <Button label="Text can wrap" />
     </div>
   </Story>
 </Preview>

--- a/src/components/interactive/button.test.js
+++ b/src/components/interactive/button.test.js
@@ -3,22 +3,17 @@ import { shallow } from 'enzyme';
 
 import Button from './Button';
 
-const renderComponent = (props) => shallow(<Button {...props} />);
-
-const buttons = {
-  Link: () => {}, isLoading: true, isDestructive: true, disabled: true, iconPlacement: 'left',
-  Icon: () => {}, isFullWidth: true, theme: 'outlined', hasCaret: true
-};
-
 describe('ButtonGroup component', () => {
 
   it('matches snapshot (default props)', () => {
-    const component = renderComponent({ children: 'Button' });
+    const component = shallow(<Button label="Button" />);
     expect(component).toMatchSnapshot();
   });
 
   it('matches snapshot (set all props)', () => {
-    const component = renderComponent(buttons);
+    const component = shallow(<Button 
+      label="Button" Link={() => {}} isLoading isDestructive disabled iconPlacement='left' Icon={() => {}} isFullWidth theme='outlined' hasCaret
+    />)
     expect(component).toMatchSnapshot();
   });
 });

--- a/src/components/interactive/stackedButton.test.js
+++ b/src/components/interactive/stackedButton.test.js
@@ -1,23 +1,19 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import Button from './Button';
+import StackedButton from './StackedButton';
 
-const renderComponent = (props) => shallow(<Button {...props} />);
-
-const buttons = {
-  Link: () => {}, disabled: true, Icon: () => {}, label: 'button', isActive: true
-};
-
-describe('ButtonGroup component', () => {
+describe('StackedButton component', () => {
 
   it('matches snapshot (default props)', () => {
-    const component = renderComponent({ label: 'Button' });
+    const component = shallow(<StackedButton label="Button" />);
     expect(component).toMatchSnapshot();
   });
 
   it('matches snapshot (set all props)', () => {
-    const component = renderComponent(buttons);
+    const component = shallow(<StackedButton 
+      Link={() => {}} disabled Icon={() => {}} label='button' isActive
+    />);
     expect(component).toMatchSnapshot();
   });
 });

--- a/src/components/layout/section.stories.mdx
+++ b/src/components/layout/section.stories.mdx
@@ -83,7 +83,7 @@ always match.
             </div>
           </FlexItem>
           <FlexItem shrink>
-            <Button>Some action</Button>
+            <Button label="Some action" />
           </FlexItem>
         </Flex>
       </Section>

--- a/src/components/modals/__snapshots__/prompt.test.js.snap
+++ b/src/components/modals/__snapshots__/prompt.test.js.snap
@@ -19,22 +19,20 @@ exports[`Prompt component matches snapshot (default props) 1`] = `
       >
         <Button
           iconPlacement="right"
+          label="bar"
           size="m"
           theme="blue"
-        >
-          bar
-        </Button>
+        />
       </FlexItem>
       <FlexItem
         shrink={true}
       >
         <Button
           iconPlacement="right"
+          label="foo"
           size="m"
           theme="blue"
-        >
-          foo
-        </Button>
+        />
       </FlexItem>
     </Flex>
   }
@@ -62,22 +60,20 @@ exports[`Prompt component matches snapshot (default props) 2`] = `
       >
         <Button
           iconPlacement="right"
+          label="bar"
           size="m"
           theme="blue"
-        >
-          bar
-        </Button>
+        />
       </FlexItem>
       <FlexItem
         shrink={true}
       >
         <Button
           iconPlacement="right"
+          label="foo"
           size="m"
           theme="blue"
-        >
-          foo
-        </Button>
+        />
       </FlexItem>
     </Flex>
   }
@@ -108,22 +104,20 @@ exports[`Prompt component matches snapshot (set all props) 1`] = `
       >
         <Button
           iconPlacement="right"
+          label="bar"
           size="m"
           theme="blue"
-        >
-          bar
-        </Button>
+        />
       </FlexItem>
       <FlexItem
         shrink={true}
       >
         <Button
           iconPlacement="right"
+          label="foo"
           size="m"
           theme="blue"
-        >
-          foo
-        </Button>
+        />
       </FlexItem>
     </Flex>
   }

--- a/src/components/modals/dialog.stories.mdx
+++ b/src/components/modals/dialog.stories.mdx
@@ -51,7 +51,7 @@ https://github.com/storybookjs/storybook/issues?q=is%3Aissue+is%3Aopen+sort%3Aup
     isOpen={true}
     content="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Donec ac odio tempor orci. Placerat vestibulum lectus mauris ultrices eros in cursus. Neque laoreet suspendisse interdum consectetur. Ut porttitor leo a diam. Quisque egestas diam in arcu cursus euismod quis viverra. Eget nunc lobortis mattis aliquam. Mauris pharetra et ultrices neque ornare aenean euismod. Luctus accumsan tortor posuere ac. At erat pellentesque adipiscing commodo elit at imperdiet dui accumsan. Non arcu risus quis varius quam quisque id diam. Vel pharetra vel turpis nunc eget lorem dolor sed. Risus quis varius quam quisque id diam vel quam elementum. Velit ut tortor pretium viverra suspendisse potenti. Amet purus gravida quis blandit turpis cursus in hac. Nunc aliquet bibendum enim facilisis gravida neque convallis a. Egestas maecenas pharetra convallis posuere morbi leo. Pellentesque pulvinar pellentesque habitant morbi tristique. Habitasse platea dictumst quisque sagittis purus. Fermentum dui faucibus in ornare quam. Facilisi etiam dignissim diam quis enim lobortis scelerisque fermentum. Viverra adipiscing at in tellus integer feugiat scelerisque varius. Turpis egestas integer eget aliquet. Bibendum est ultricies integer quis auctor elit sed vulputate. Scelerisque viverra mauris in aliquam sem fringilla ut morbi. Lectus urna duis convallis convallis tellus id interdum velit. A arcu cursus vitae congue mauris rhoncus aenean. Odio euismod lacinia at quis risus sed vulputate odio. Nibh tellus molestie nunc non. Egestas egestas fringilla phasellus faucibus scelerisque eleifend donec. Amet nisl suscipit adipiscing bibendum est ultricies integer quis auctor. A erat nam at lectus urna duis convallis convallis. Faucibus scelerisque eleifend donec pretium vulputate sapien nec. Mauris sit amet massa vitae tortor condimentum lacinia. Ut sem nulla pharetra diam sit amet nisl suscipit adipiscing. In fermentum et sollicitudin ac orci phasellus egestas tellus rutrum. Risus quis varius quam quisque id diam vel. Id nibh tortor id aliquet. Nisi quis eleifend quam adipiscing vitae proin."
     onDismiss={action('close modal')}
-    footerContent={<Button>Confirm</Button>}
+    footerContent={<Button label="Confirm" />}
     title="Long content area w/footer"
   />
 </Story>
@@ -59,16 +59,16 @@ https://github.com/storybookjs/storybook/issues?q=is%3Aissue+is%3Aopen+sort%3Aup
 <Story name="Customizable Footer">
   <Dialog
     isOpen={true}
-    content={<Button>Customizable footer</Button>}
+    content={<Button label="Customizable footer" />}
     onDismiss={action('close modal')}
     footerContent={
       <div>
         <Flex align="center">
           <FlexItem shrink>
-            <Button>Anything</Button>
+            <Button label="Anything" />
           </FlexItem>
           <FlexItem shrink>
-            <Button theme="outlined">Can go</Button>
+            <Button theme="outlined" label="Can go" />
           </FlexItem>
           <FlexItem shrink>
             <p>in the</p>

--- a/src/components/modals/prompt.stories.mdx
+++ b/src/components/modals/prompt.stories.mdx
@@ -14,13 +14,13 @@ import Prompt from "./Prompt";
 export const primaryButtonProps = () =>
   object("primaryButton", {
     isDestructive: true,
-    children: "Yes, delete"
+    label: "Yes, delete"
   });
 
 export const secondaryButtonProps = () =>
   object("secondaryButton", {
     theme: "ghost",
-    children: "Keep Collection",
+    label: "Keep Collection",
     onClick: action("close modal"),
     }
   );

--- a/src/components/modals/prompt.test.js
+++ b/src/components/modals/prompt.test.js
@@ -6,20 +6,20 @@ import Button from '../interactive/Button'
 describe('Prompt component', () => {
 
   it('matches snapshot (default props)', () => {
-    const component = shallow(<Prompt primaryButton={<Button>foo</Button>} secondaryButton={<Button>bar</Button>} />);
+    const component = shallow(<Prompt primaryButton={<Button label="foo" />} secondaryButton={<Button label="bar" />} />);
     expect(component).toMatchSnapshot();
-    const component2 = shallow(<Prompt isOpen={true} primaryButton={<Button>foo</Button>} secondaryButton={<Button>bar</Button>} />);
+    const component2 = shallow(<Prompt isOpen primaryButton={<Button label="foo" />} secondaryButton={<Button label="bar" />} />);
     expect(component2).toMatchSnapshot();
   });
 
   it('matches snapshot (set all props)', () => {
     const component = shallow(
       <Prompt 
-        primaryButton={<Button>foo</Button>} 
-        secondaryButton={<Button>bar</Button>} 
+        primaryButton={<Button label="foo" />} 
+        secondaryButton={<Button label="bar" />} 
         title="title"
         desc="desc"
-        isOpen={true}
+        isOpen
       />
     );
     expect(component).toMatchSnapshot();

--- a/src/components/popovers/popover.stories.mdx
+++ b/src/components/popovers/popover.stories.mdx
@@ -24,7 +24,7 @@ Base popover component. Bring your own trigger and popover content.
 
 <Story name="Knobs">
   <Popover
-    trigger={<div className="margin--bottom"><Button>Click Me</Button></div>}
+    trigger={<div className="margin--bottom"><Button label="Click Me" /></div>}
     position={options('Position', arrayToOptions(VALID_POSITIONS), 'bottom', {
       display: 'inline-radio',
     })}
@@ -63,7 +63,7 @@ Base popover component. Bring your own trigger and popover content.
 <Preview>
   <Story name="Styled popover content" height={100}>
     <Popover
-      trigger={<Button theme="outlined">Open popover</Button>}
+      trigger={<Button theme="outlined" label="Open popover" />}
       position="bottom"
       alignment="start"
       distance={8}


### PR DESCRIPTION
## Description
Right now Button accepts arbitrary JSX, so developers could put unapproved things inside Button. Realistically this should only ever be a string. Because of the convention of children generally allowing JSX, I've switched the prop to be a label, and now it must be a string (it's also a required field now).

This is a breaking change, hence why it's being done in `release/7.0`.

## Screenshots
N/A

## Checklist
- [x] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [x] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**