### PR TITLE
fix popover bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ This is an example of a brief overview of the _Major_ or _Minor_ version changes
 
 ---
 
+## [7.5] Popover positioning
+
+- 🐛 Fixed bug where `Popover` boundary was the nearest parent with `overflow` set. `Popover`
+  will now use `window` as the reference element to avoid content overflow.
+
 ## [7.4] Updated Buttons
 
 - `outlined` Button now has updated presentation (white background,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ This is an example of a brief overview of the _Major_ or _Minor_ version changes
 ## [7.5] Popover positioning
 
 - 🐛 Fixed bug where `Popover` boundary was the nearest parent with `overflow` set. `Popover`
-  will now use `window` as the reference element to avoid content overflow.
+  will now use the entire visible viewport area the reference to avoid content overflow.
 
 ## [7.4] Updated Buttons
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@
 * Jenkins populates the patch version depending on the branch.
 */
 
-String VERSION = "7.4"
+String VERSION = "7.5"
 
 /* ---- DO NOT EDIT BELOW (unless you really know what you're doing) ---- */
 

--- a/src/components/popovers/Popover.jsx
+++ b/src/components/popovers/Popover.jsx
@@ -129,6 +129,9 @@ const Popover = ({
       enabled: true,
       offset: `0,${distance}`,
     },
+    preventOverflow: {
+      boundariesElement: 'window',
+    },
     computeStyle: {
       // When gpuAcceleration is enabled, `react-popper` always
       // positions content to top/left 0 and uses `translate3d` to

--- a/src/components/popovers/Popover.jsx
+++ b/src/components/popovers/Popover.jsx
@@ -130,7 +130,7 @@ const Popover = ({
       offset: `0,${distance}`,
     },
     preventOverflow: {
-      boundariesElement: 'window',
+      boundariesElement: 'viewport',
     },
     computeStyle: {
       // When gpuAcceleration is enabled, `react-popper` always


### PR DESCRIPTION
## Description
Make `react-popper` use the `viewport` as the boundary instead of nearest overflowing parent.

## Screenshots
before/after
![Screen Shot 2020-02-10 at 12 49 01 PM](https://user-images.githubusercontent.com/231252/74176119-13dcb400-4c05-11ea-9bcf-46cf3389d211.png)
![Screen Shot 2020-02-10 at 12 49 14 PM](https://user-images.githubusercontent.com/231252/74176120-13dcb400-4c05-11ea-907a-695dffc1ace7.png)


## Checklist
- [x] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [x] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**

