### PR TITLE
UIP-505: importpath

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -293,4 +293,23 @@
     background-clip: content-box;
   }
 
+  .importPath {
+    color: #333;
+    font-size: 14px;
+    cursor: pointer;
+    font-family: "Operator Mono","Fira Code Retina","Fira Code","FiraCode-Retina","Andale Mono","Lucida Console",Consolas,Monaco,monospace;
+  }
+
+  .importPath--highlight {
+    color: #006699;
+  }
+
+  .importPath:hover, .importPath:hover svg {
+    color: darkorange;
+  }
+
+  .importPath:hover .importPath--highlight {
+    color: orange;
+  }
+
 </style>

--- a/src/components/forms/checkbox.stories.mdx
+++ b/src/components/forms/checkbox.stories.mdx
@@ -1,12 +1,14 @@
 import { Meta, Story, Preview, Props, Source } from "@storybook/addon-docs/blocks";
 import { withKnobs, text, boolean } from '@storybook/addon-knobs';
-import { Info } from '../util/storybook';
+import { Info, ImportPath } from '../util/storybook';
 
 import Checkbox from './Checkbox';
 
 <Meta title="Components/Forms/Checkbox" decorators={[withKnobs]} component={Checkbox} />
 
 # Checkbox
+
+<ImportPath component={Checkbox} section="forms" />
 
 Uncontrolled custom checkbox component with optional label.
 

--- a/src/components/forms/checkbox.stories.mdx
+++ b/src/components/forms/checkbox.stories.mdx
@@ -21,7 +21,7 @@ Uncontrolled custom checkbox component with optional label.
 
 <Source
   language="jsx"
-  code='<Checkbox label="I agree to receive spam" />'
+  code="import Button from 'button'"
 />
 
 <Info type="info">

--- a/src/components/forms/decoratedInput.stories.mdx
+++ b/src/components/forms/decoratedInput.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 import { withKnobs, text } from '@storybook/addon-knobs';
+import { ImportPath } from '../util/storybook';
 
 import Flex from '../layout/Flex';
 import FlexItem from '../layout/FlexItem';
@@ -8,6 +9,8 @@ import DecoratedInput from './DecoratedInput';
 <Meta title="Components/Forms/DecoratedInput" decorators={[withKnobs]} component={DecoratedInput} />
 
 # DecoratedInput
+
+<ImportPath component={DecoratedInput} section="forms" />
 
 Wrapper for `input` elements to add contextual labels to either side of the
 input. **Side labels are not a substitute for `label` elements!**

--- a/src/components/forms/iconInput.stories.mdx
+++ b/src/components/forms/iconInput.stories.mdx
@@ -8,9 +8,13 @@ import StarFilledIcon from '../../../lib/icons/react/StarFilledIcon';
 
 import IconInput from './IconInput';
 
+import { ImportPath } from '../util/storybook';
+
 <Meta title="Components/Forms/IconInput" decorators={[withKnobs]} component={IconInput} />
 
 # IconInput
+
+<ImportPath component={IconInput} section="forms" />
 
 <Story name="Knobs">
   <React.Fragment>

--- a/src/components/forms/inputGroup.stories.mdx
+++ b/src/components/forms/inputGroup.stories.mdx
@@ -4,9 +4,13 @@ import DecoratedInput from './DecoratedInput';
 import IconInput from './IconInput';
 import SearchIcon from '../../../lib/icons/react/SearchIcon';
 
+import { ImportPath } from '../util/storybook';
+
 <Meta title="Components/Forms/InputGroup" component={InputGroup} />
 
 # InputGroup
+
+<ImportPath component={InputGroup} section="forms" />
 
 Visually groups multiple form fields on one line.
 

--- a/src/components/forms/radio.stories.mdx
+++ b/src/components/forms/radio.stories.mdx
@@ -1,12 +1,14 @@
 import { Meta, Story, Preview, Props, Source } from "@storybook/addon-docs/blocks";
 import { withKnobs, text, boolean } from '@storybook/addon-knobs';
-import { Info } from '../util/storybook';
+import { Info, ImportPath } from '../util/storybook';
 
 import Radio from './Radio';
 
 <Meta title="Components/Forms/Radio" decorators={[withKnobs]} component={Radio} />
 
 # Radio
+
+<ImportPath component={Radio} section="forms" />
 
 Uncontrolled custom radio component with label.
 

--- a/src/components/interactive/button.stories.mdx
+++ b/src/components/interactive/button.stories.mdx
@@ -5,7 +5,7 @@ import {
   boolean,
   optionsKnob as options
 } from "@storybook/addon-knobs";
-import { arrayToOptions, StoryWrapper, StoryItem } from "components/util/storybook";
+import { arrayToOptions, StoryWrapper, StoryItem, ImportPath } from "components/util/storybook";
 import Button, { SIZES, THEMES, ICON_PLACEMENTS } from "./Button";
 import StarFilledIcon from "lib/icons/react/StarFilledIcon";
 import IconButton from "./IconButton";
@@ -14,6 +14,8 @@ import ButtonGroup from "./ButtonGroup";
 <Meta title="Components/Interactive/Button" decorators={[withKnobs]} component={Button} />
 
 # Button
+
+<ImportPath component={Button} section="interactive" />
 
 <Story name="Knobs" parameters={{ docs: { disable: true }}}>
   <div className={boolean("Inverted", false) ? 'inverted' : ''}>

--- a/src/components/interactive/buttonGroup.stories.mdx
+++ b/src/components/interactive/buttonGroup.stories.mdx
@@ -1,11 +1,13 @@
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 import { withKnobs, object } from '@storybook/addon-knobs';
-
-import ButtonGroup from './ButtonGroup';
-import GroupButton from './GroupButton';
 import Updatable from 'components/media/Updatable'
 import Tooltip from 'components/popovers/Tooltip'
 import FeedIcon from 'lib/icons/react/FeedIcon';
+
+import ButtonGroup from './ButtonGroup';
+import GroupButton from './GroupButton';
+
+import { ImportPath } from '../util/storybook';
 
 export const buttons = [
   { label: 'Lorem', Icon: FeedIcon, isActive: true },
@@ -21,10 +23,11 @@ export const buttonsNoIcons = [
   { label: 'Sit' },
 ];
 
-
 <Meta title="Components/Interactive/ButtonGroup" decorators={[withKnobs]} component={ButtonGroup} />
 
 # ButtonGroup
+
+<ImportPath component={ButtonGroup} section="interactive" />
 
 <Story name="Knobs">
   <ButtonGroup buttons={object('buttons', buttonsNoIcons)} />

--- a/src/components/interactive/chip.stories.mdx
+++ b/src/components/interactive/chip.stories.mdx
@@ -6,7 +6,7 @@ import {
   boolean,
   optionsKnob as options
 } from "@storybook/addon-knobs";
-import { arrayToOptions } from "../util/storybook";
+import { arrayToOptions, ImportPath } from "../util/storybook";
 
 import Chip, { THEMES, SIZES } from "./Chip";
 
@@ -31,6 +31,8 @@ export const chipsTwo = [
 <Meta title="Components/Interactive/Chip" decorators={[withKnobs]} component={Chip} />
 
 # Chip
+
+<ImportPath component={Chip} section="interactive" />
 
 <Story name="Knobs">
   <Chip

--- a/src/components/interactive/dropdownButton.stories.mdx
+++ b/src/components/interactive/dropdownButton.stories.mdx
@@ -5,11 +5,14 @@ import {
   boolean,
   optionsKnob as options
 } from "@storybook/addon-knobs";
+import { ImportPath } from '../util/storybook';
 import DropdownButton from "./DropdownButton";
 
 <Meta title="Components/Interactive/DropdownButton" decorators={[withKnobs]} component={DropdownButton} />
 
 # DropdownButton
+
+<ImportPath component={DropdownButton} section="interactive" />
 
 <Preview isExpanded>
   <DropdownButton>Filter by Analyst</DropdownButton>

--- a/src/components/interactive/floatingAction.stories.mdx
+++ b/src/components/interactive/floatingAction.stories.mdx
@@ -1,13 +1,15 @@
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 import { withKnobs, boolean, text, optionsKnob as options } from '@storybook/addon-knobs';
 import ApproveIcon from '../../../lib/icons/react/ApproveIcon';
-import { arrayToOptions } from '../util/storybook';
+import { arrayToOptions, ImportPath } from '../util/storybook';
 
 import FloatingAction, { VALID_FAB_THEMES } from './FloatingAction';
 
 <Meta title="Components/Interactive/FloatingAction" decorators={[withKnobs]} component={FloatingAction} />
 
 # FloatingAction
+
+<ImportPath component={FloatingAction} section="interactive" />
 
 <Story name="Knobs">
   <FloatingAction

--- a/src/components/interactive/iconButton.stories.mdx
+++ b/src/components/interactive/iconButton.stories.mdx
@@ -5,7 +5,7 @@ import CollectionPublicIcon from '../../../lib/icons/react/CollectionPublicIcon'
 import StoryAddIcon from '../../../lib/icons/react/StoryAddIcon';
 import WorkFasterIcon from '../../../lib/icons/react/WorkFasterIcon';
 import SalesforceIcon from '../../../lib/icons/react/SalesforceIcon';
-import { arrayToOptions } from '../util/storybook';
+import { arrayToOptions, ImportPath } from '../util/storybook';
 import { MockLink } from '../util/mock-react-router';
 
 import IconButton, { THEMES, RADII, SIZES } from './IconButton';
@@ -15,6 +15,8 @@ export const Icons = [StarFilledIcon, CollectionPublicIcon, StoryAddIcon, WorkFa
 <Meta title="Components/Interactive/IconButton" decorators={[withKnobs]} component={IconButton} />
 
 # IconButton
+
+<ImportPath component={IconButton} section="interactive" />
 
 <Story name="Knobs">
   <IconButton

--- a/src/components/interactive/stackedButton.stories.mdx
+++ b/src/components/interactive/stackedButton.stories.mdx
@@ -9,9 +9,13 @@ import SalesforceIcon from '../../../lib/icons/react/SalesforceIcon';
 
 import StackedButton from './StackedButton';
 
+import { ImportPath } from '../util/storybook';
+
 <Meta title="Components/Interactive/StackedButton" decorators={[withKnobs]} component={StackedButton} />
 
 # StackedButton
+
+<ImportPath component={StackedButton} section="interactive" />
 
 <Story name="Knobs">
   <StackedButton

--- a/src/components/interactive/toast.stories.mdx
+++ b/src/components/interactive/toast.stories.mdx
@@ -10,9 +10,13 @@ import {
 
 import Toast from './Toast';
 
+import { ImportPath } from '../util/storybook';
+
 <Meta title="Components/Interactive/Toast" decorators={[withKnobs]} component={Toast} />
 
 # Toast
+
+<ImportPath component={Toast} section="interactive" />
 
 <Story name="Knobs">
   <Toast

--- a/src/components/interactive/toaster.stories.mdx
+++ b/src/components/interactive/toaster.stories.mdx
@@ -110,7 +110,7 @@ export const ToasterStory = () => {
 
 # Toaster
 
-<ImportPath component={Toast} section="interactive" />
+<ImportPath component={Toaster} section="interactive" />
 
 Controller for positioning, transition, and dismissal of toasts.
 

--- a/src/components/interactive/toaster.stories.mdx
+++ b/src/components/interactive/toaster.stories.mdx
@@ -5,6 +5,8 @@ import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react';
 import { withKnobs, select } from '@storybook/addon-knobs';
 
+import { ImportPath } from '../util/storybook';
+
 import Toaster from './Toaster';
 import Toast from './Toast';
 
@@ -107,6 +109,8 @@ export const ToasterStory = () => {
 <Meta title="Components/Interactive/Toaster" decorators={[withKnobs]} component={Toaster} />
 
 # Toaster
+
+<ImportPath component={Toast} section="interactive" />
 
 Controller for positioning, transition, and dismissal of toasts.
 

--- a/src/components/layout/flex.stories.mdx
+++ b/src/components/layout/flex.stories.mdx
@@ -1,6 +1,8 @@
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 import { withKnobs, boolean, radios } from '@storybook/addon-knobs';
 
+import { ImportPath } from '../util/storybook';
+
 import Flex from './Flex';
 import FlexItem from './FlexItem';
 
@@ -38,6 +40,8 @@ export const ConditionalItemsExample = (props) => (
 <Meta title="Components/Layout/Flex" decorators={[withKnobs]} component={Flex} />
 
 # Flex
+
+<ImportPath component={Flex} section="layout" />
 
 Flex is an abstraction of CSS flexbox that provides a subset of flexbox functionality. **A `Flex` should only contain `FlexItem` children**.
 

--- a/src/components/layout/flexItem.stories.mdx
+++ b/src/components/layout/flexItem.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 import { withKnobs, boolean, select } from '@storybook/addon-knobs';
+import { ImportPath } from '../util/storybook';
 
 import Flex from './Flex';
 import FlexItem from './FlexItem';
@@ -18,6 +19,9 @@ export const getAlignKnob = label =>
 <Meta title="Components/Layout/FlexItem" decorators={[withKnobs]} component={FlexItem} />
 
 # FlexItem
+
+<ImportPath component={FlexItem} section="layout" />
+
 Direct parent must be `<Flex>`
 
 <Story name="Knobs">

--- a/src/components/layout/hscroll.stories.mdx
+++ b/src/components/layout/hscroll.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 import { withKnobs, boolean, radios } from '@storybook/addon-knobs';
+import { ImportPath } from '../util/storybook';
 
 import Hscroll from './Hscroll';
 
@@ -18,6 +19,8 @@ export const ExampleItem = props => (
 <Meta title="Components/Layout/Hscroll" decorators={[withKnobs]} component={Hscroll} />
 
 # Hscroll
+
+<ImportPath component={Hscroll} section="layout" />
 
 <Story name="Knobs">
   <Hscroll

--- a/src/components/layout/inlineBlockList.stories.mdx
+++ b/src/components/layout/inlineBlockList.stories.mdx
@@ -1,5 +1,6 @@
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 import { withKnobs, text, select } from '@storybook/addon-knobs';
+import { ImportPath } from '../util/storybook';
 
 import InlineBlockList from './InlineBlockList';
 import Chip from '../interactive/Chip';
@@ -12,6 +13,7 @@ export const parentStyle = {
 <Meta title="Components/Layout/InlineBlockList" decorators={[withKnobs]} component={InlineBlockList} />
 
 # InlineBlockList
+<ImportPath component={InlineBlockList} section="layout" />
 
 <Story name="Knobs">
   <InlineBlockList

--- a/src/components/layout/section.stories.mdx
+++ b/src/components/layout/section.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 import { withKnobs, optionsKnob as options, select } from '@storybook/addon-knobs';
-import { arrayToOptions, storyBackgrounds } from '../util/storybook';
+import { arrayToOptions, storyBackgrounds, ImportPath } from '../util/storybook';
 
 import Section, { VALID_BG_NORMAL, VALID_BG_INVERTED, VALID_PADDING } from './Section';
 import Flex from './Flex';
@@ -17,6 +17,8 @@ export const parentStyle = {
 <Meta title="Components/Layout/Section" decorators={[withKnobs]} component={Section} />
 
 # Section
+
+<ImportPath component={Section} section="layout" />
 
 Section is a layout component that can be used for sectioning content either vertically or
 horizontally.

--- a/src/components/media/Avatar.stories.mdx
+++ b/src/components/media/Avatar.stories.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 import { withKnobs, text, optionsKnob as options } from '@storybook/addon-knobs';
-import { arrayToOptions, StoryWrapper, StoryItem } from '../util/storybook';
+import { arrayToOptions, StoryWrapper, StoryItem, ImportPath } from '../util/storybook';
 import { action } from '@storybook/addon-actions';
 
 import Avatar, { BG_COLORS, SIZES, RADII, INITIALS_LENGTH } from './Avatar';
@@ -12,6 +12,8 @@ export const bgColorOptions = options('bgColor', arrayToOptions(BG_COLORS), unde
 <Meta title="Components/Media/Avatar" decorators={[withKnobs]} component={Avatar} />
 
 # Avatar
+
+<ImportPath component={Avatar} section="media" />
 
 <Story name="Knobs">
   <StoryWrapper>

--- a/src/components/media/Badge.stories.mdx
+++ b/src/components/media/Badge.stories.mdx
@@ -1,12 +1,14 @@
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 import { withKnobs, text, optionsKnob as options } from '@storybook/addon-knobs';
-import { arrayToOptions } from '../util/storybook';
+import { arrayToOptions, ImportPath } from '../util/storybook';
 
 import Badge, { SIZES } from './Badge';
 
 <Meta title="Components/Media/Badge" decorators={[withKnobs]} component={Badge} />
 
 # Badge
+
+<ImportPath component={Badge} section="layout" />
 
 <Story name="Badge">
   <Badge 

--- a/src/components/media/Badge.stories.mdx
+++ b/src/components/media/Badge.stories.mdx
@@ -8,7 +8,7 @@ import Badge, { SIZES } from './Badge';
 
 # Badge
 
-<ImportPath component={Badge} section="layout" />
+<ImportPath component={Badge} section="media" />
 
 <Story name="Badge">
   <Badge 

--- a/src/components/media/countdownButton.stories.mdx
+++ b/src/components/media/countdownButton.stories.mdx
@@ -2,11 +2,15 @@ import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 import { action } from '@storybook/addon-actions';
 import { withKnobs, number } from '@storybook/addon-knobs';
 
+import { ImportPath } from '../util/storybook';
+
 import CountdownButton from './CountdownButton';
 
-<Meta title="Components/Interactive/CountdownButton" decorators={[withKnobs]} component={CountdownButton} />
+<Meta title="Components/Media/CountdownButton" decorators={[withKnobs]} component={CountdownButton} />
 
 # CountdownButton
+
+<ImportPath component={CountdownButton} section="media" />
 
 An icon button that shows a radial countdown animation immediately on mount.
 

--- a/src/components/media/updatable.stories.mdx
+++ b/src/components/media/updatable.stories.mdx
@@ -3,11 +3,15 @@ import { withKnobs, text } from '@storybook/addon-knobs';
 
 import CheckIcon from '../../../lib/icons/react/CheckIcon';
 
+import { ImportPath } from '../util/storybook';
+
 import Updatable from './Updatable';
 
 <Meta title="Components/Media/Updatable" decorators={[withKnobs]} component={Updatable} />
 
 # Updatable
+
+<ImportPath component={Updatable} section="layout" />
 
 Wraps children in an "updatable" container with a `message` displayed as a notification-style red bubble.
 

--- a/src/components/modals/dialog.stories.mdx
+++ b/src/components/modals/dialog.stories.mdx
@@ -1,6 +1,7 @@
 import { Meta, Story, Preview, Props, Description } from "@storybook/addon-docs/blocks";
 import { withKnobs, text, boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
+import { ImportPath } from '../util/storybook';
 
 import Dialog from './Dialog';
 
@@ -14,6 +15,8 @@ import MenuItem from '../popovers/MenuItem';
 <Meta title="Components/Modals/Dialog" decorators={[withKnobs]} component={Dialog} parameters={{ docs: { disable: true } }}/>
 
 # Dialog
+
+<ImportPath component={Dialog} section="modal" />
 
 *Please click **"Canvas"** to view examples.*
 

--- a/src/components/modals/prompt.stories.mdx
+++ b/src/components/modals/prompt.stories.mdx
@@ -7,6 +7,7 @@ import {
 } from "@storybook/addon-docs/blocks";
 import { withKnobs, text, boolean, object } from "@storybook/addon-knobs";
 import { action } from '@storybook/addon-actions';
+import { ImportPath } from '../util/storybook';
 import Button from "../interactive/Button";
 
 import Prompt from "./Prompt";
@@ -33,6 +34,8 @@ export const secondaryButtonProps = () =>
 />
 
 # Prompt
+
+<ImportPath component={Prompt} section="modal" />
 
 *Please click **"Canvas"** to view examples.*
 

--- a/src/components/popovers/menu.stories.mdx
+++ b/src/components/popovers/menu.stories.mdx
@@ -8,22 +8,28 @@ import {
 } from "@storybook/addon-knobs";
 import { action } from '@storybook/addon-actions';
 
-import Menu from './Menu';
-import MenuItem from './MenuItem';
+import Button from 'components/interactive/Button';
 
-import Button from '../interactive/Button';
-
-import Flex from '../layout/Flex';
-import FlexItem from '../layout/FlexItem';
+import Flex from 'components/layout/Flex';
+import FlexItem from 'components/layout/FlexItem';
 
 import CloneIcon from 'lib/icons/react/CloneIcon';
 import TrashIcon from 'lib/icons/react/TrashIcon';
 import EditIcon from 'lib/icons/react/EditIcon';
 import FundingIcon from 'lib/icons/react/FundingIcon';
 
+import { ImportPath } from '../util/storybook';
+
+import Menu from './Menu';
+import MenuItem from './MenuItem';
+
+
 <Meta title="Components/Popovers/Menu" component={Menu} decorators={[withKnobs]} />
 
 # Menu
+
+<ImportPath component={Menu} section="popovers" />
+<ImportPath component={MenuItem} section="popovers" />
 
 Renders a basic keyboard navigable dropdown menu following the [WAI-ARIA pattern for "menubutton"](https://www.w3.org/TR/wai-aria-practices-1.1/#menubutton).
 

--- a/src/components/popovers/popover.stories.mdx
+++ b/src/components/popovers/popover.stories.mdx
@@ -14,11 +14,17 @@ import Popover, {
   VALID_POSITIONS,
   VALID_INTERACTION_MODES,
 } from './Popover';
+
+import { ImportPath } from '../util/storybook';
+
 import Button from '../interactive/Button';
+
 
 <Meta title="Components/Popovers/Popover" decorators={[withKnobs]} component={Popover} />
 
 # Popover
+
+<ImportPath component={Popover} section="popovers" />
 
 Base popover component. Bring your own trigger and popover content.
 

--- a/src/components/popovers/tooltip.stories.mdx
+++ b/src/components/popovers/tooltip.stories.mdx
@@ -1,11 +1,15 @@
 import { Meta, Story, Preview, Props } from "@storybook/addon-docs/blocks";
 import { withKnobs, text, number } from '@storybook/addon-knobs';
 
+import { ImportPath } from '../util/storybook';
+
 import Tooltip from './Tooltip';
 
 <Meta title="Components/Popovers/Tooltip" decorators={[withKnobs]} component={Tooltip} />
 
 # Tooltip
+
+<ImportPath component={Tooltip} section="popovers" />
 
 <Story name="Knobs">
   <Tooltip

--- a/src/components/util/storybook.js
+++ b/src/components/util/storybook.js
@@ -122,7 +122,7 @@ export const ImportPath = ({ component, section }) => {
 
   return (
     <p
-      className="importPath"
+      className="importPath margin--bottom"
       onMouseEnter={toggleHover}
       onMouseLeave={toggleHover}
       onClick={() => copyToClipboard(path)}

--- a/src/components/util/storybook.js
+++ b/src/components/util/storybook.js
@@ -1,5 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import CloneIcon from 'lib/icons/react/CloneIcon';
+import CheckIcon from 'lib/icons/react/CheckIcon';
 import FDS from '../../../lib/dictionary/js/styleConstants';
 
 /**
@@ -108,4 +110,44 @@ export const storyBackgrounds = {
     'url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAFCAYAAACNbyblAAAAJ0lEQVQYV2NkQAP/b///z4gsBhZQZWSEC8IEQIrAgsgCYEF0AZAgAAvKE968p7/mAAAAAElFTkSuQmCC)',
   check:
     'url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAcAAAAHCAYAAADEUlfTAAAAHElEQVQYV2M8fPiwLwMOwAiStLW13YxNftBJAgAx2BqeI9XcBAAAAABJRU5ErkJggg==)',
+};
+
+export const ImportPath = ({ component, section }) => {
+  const [, toggleHover] = useToggleHover();
+  const [copiedText, copyToClipboard] = useClipboard();
+
+  const path = `import ${component.displayName} from '@cbinsights/fds/lib/components/${section}/${component.displayName}'`;
+
+  const pathParts = path.split(' ');
+
+  return (
+    <p
+      className="importPath"
+      onMouseEnter={toggleHover}
+      onMouseLeave={toggleHover}
+      onClick={() => copyToClipboard(path)}
+    >
+      <span>{pathParts[0]} </span>
+      <span className="importPath--highlight">{pathParts[1]} </span>
+      <span>{pathParts[2]} </span>
+      <span className="importPath--highlight">{pathParts[3]}</span>
+      {!copiedText ? (
+        <CloneIcon customSize={14} />
+      ) : (
+        <CheckIcon customSize={14} color="green" />
+      )}
+    </p>
+  );
+};
+
+ImportPath.propTypes = {
+  component: PropTypes.string,
+  section: PropTypes.oneOf([
+    'forms',
+    'interactive',
+    'layout',
+    'media',
+    'modals',
+    'popovers',
+  ]),
 };

--- a/src/components/util/storybook.js
+++ b/src/components/util/storybook.js
@@ -141,7 +141,7 @@ export const ImportPath = ({ component, section }) => {
 };
 
 ImportPath.propTypes = {
-  component: PropTypes.string,
+  component: PropTypes.func,
   section: PropTypes.oneOf([
     'forms',
     'interactive',

--- a/src/components/util/storybook.js
+++ b/src/components/util/storybook.js
@@ -113,7 +113,7 @@ export const storyBackgrounds = {
 };
 
 export const ImportPath = ({ component, section }) => {
-  const [, toggleHover] = useToggleHover();
+  const toggleHover = useToggleHover()[1];
   const [copiedText, copyToClipboard] = useClipboard();
 
   const path = `import ${component.displayName} from '@cbinsights/fds/lib/components/${section}/${component.displayName}'`;


### PR DESCRIPTION
## Description
Added ImportPath to all documentation components.

This looks better on stories that have the code snippet (Only `Button` right now). When we eventually come back and add this, these stories will look a whole lot better.

## Screenshots
<img width="1440" alt="Screen Shot 2020-03-06 at 3 19 01 PM" src="https://user-images.githubusercontent.com/52427513/76128191-a177ad80-5fd1-11ea-8d29-8207ab967a4f.png">

## Checklist
- [x] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [x] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**