### PR TITLE
add snippets to all component stories except layout

### DIFF
--- a/src/components/forms/checkbox.stories.mdx
+++ b/src/components/forms/checkbox.stories.mdx
@@ -12,7 +12,7 @@ import Checkbox from './Checkbox';
 
 Uncontrolled custom checkbox component with optional label.
 
-<Story name="Knobs">
+<Story name="Knobs" parameters={{ docs: { disable: true }}}>
   <Checkbox
     indeterminate={boolean('indeterminate', false)}
     disabled={boolean('disabled', false)}
@@ -21,10 +21,12 @@ Uncontrolled custom checkbox component with optional label.
   />
 </Story>
 
-<Source
-  language="jsx"
-  code="import Button from 'button'"
-/>
+<Preview isExpanded>
+  <Checkbox
+    name="knobs"
+    label='I agree to receive spam'
+  />
+</Preview>
 
 <Info type="info">
   Additional props will be spread on the `input` element.

--- a/src/components/forms/decoratedInput.stories.mdx
+++ b/src/components/forms/decoratedInput.stories.mdx
@@ -15,7 +15,7 @@ import DecoratedInput from './DecoratedInput';
 Wrapper for `input` elements to add contextual labels to either side of the
 input. **Side labels are not a substitute for `label` elements!**
 
-<Story name="Knobs">
+<Story name="Knobs" parameters={{ docs: { disable: true }}}>
   <React.Fragment>
     <p className="margin--bottom type--data color--purple fontStyle--italic">
       Use the knobs panel to change left and right labels
@@ -30,8 +30,19 @@ input. **Side labels are not a substitute for `label` elements!**
   </React.Fragment>
 </Story>
 
-<Props of={DecoratedInput} />
+<Preview isExpanded>
+  <React.Fragment>
+    <label htmlFor="horseName">Name your horse</label>
+    <DecoratedInput
+      before='before'
+      after='after'
+    >
+      <input id="horseName" type="text" />
+    </DecoratedInput>
+  </React.Fragment>
+</Preview>
 
+<Props of={DecoratedInput} />
 
 ### Before
 

--- a/src/components/forms/iconInput.stories.mdx
+++ b/src/components/forms/iconInput.stories.mdx
@@ -16,7 +16,7 @@ import { ImportPath } from '../util/storybook';
 
 <ImportPath component={IconInput} section="forms" />
 
-<Story name="Knobs">
+<Story name="Knobs" parameters={{ docs: { disable: true }}}>
   <React.Fragment>
     <IconInput
       IconLeft={boolean('Left star', true) ? StarFilledIcon : undefined}
@@ -26,6 +26,15 @@ import { ImportPath } from '../util/storybook';
     </IconInput>
   </React.Fragment>
 </Story>
+
+<Preview isExpanded>
+  <IconInput
+    IconLeft={StarFilledIcon}
+    IconRight={StarFilledIcon}
+  >
+    <input type="text" placeholder={text('Placeholder text', 'My god, its full of stars!')} />
+  </IconInput>
+</Preview>
 
 <Props of={IconInput} />
 

--- a/src/components/forms/radio.stories.mdx
+++ b/src/components/forms/radio.stories.mdx
@@ -12,7 +12,7 @@ import Radio from './Radio';
 
 Uncontrolled custom radio component with label.
 
-<Story name="Knobs">
+<Story name="Knobs" parameters={{ docs: { disable: true }}}>
   <Radio
     disabled={boolean('disabled', false)}
     name="knobs"
@@ -20,10 +20,9 @@ Uncontrolled custom radio component with label.
   />
 </Story>
 
-<Source
-  language="jsx"
-  code='<Radio name="radio-group-name" label="I agree to receive spam" />'
-/>
+<Preview isExpanded>
+  <Radio name="radio-group-name" label="I agree to receive spam" />
+</Preview>
 
 <Info type="info">
   Additional props will be spread on the `input` element.

--- a/src/components/interactive/IconButton.jsx
+++ b/src/components/interactive/IconButton.jsx
@@ -81,9 +81,9 @@ IconButton.propTypes = {
   /** Controls whether the button is disabled or not. */
   disabled: PropTypes.bool,
   /** Used to render a FDS Icon (should only be used for FDS Icons) */
-  Icon: PropTypes.func,
+  Icon: PropTypes.func.isRequired,
   /** Accessibility label */
-  label: PropTypes.string,
+  label: PropTypes.string.isRequired,
 };
 
 export default IconButton;

--- a/src/components/interactive/Toaster.jsx
+++ b/src/components/interactive/Toaster.jsx
@@ -58,6 +58,8 @@ const Toaster = ({ toast }) => {
   );
 };
 
+Toaster.displayName = 'Toaster';
+
 Toaster.propTypes = {
   /** a `Toast` element */
   toast: PropTypes.element,

--- a/src/components/interactive/buttonGroup.stories.mdx
+++ b/src/components/interactive/buttonGroup.stories.mdx
@@ -29,9 +29,19 @@ export const buttonsNoIcons = [
 
 <ImportPath component={ButtonGroup} section="interactive" />
 
-<Story name="Knobs">
+<Story name="Knobs" parameters={{ docs: { disable: true }}}>
   <ButtonGroup buttons={object('buttons', buttonsNoIcons)} />
 </Story>
+
+<Preview isExpanded>
+  <ButtonGroup
+    buttons={[
+      { label: 'Lorem', disabled: true },
+      { label: 'Ipsum' },
+      { label: 'Dolor', isActive: true }
+    ]} 
+  />
+</Preview>
 
 <Props of={ButtonGroup} />
 <Props of={GroupButton} />

--- a/src/components/interactive/chip.stories.mdx
+++ b/src/components/interactive/chip.stories.mdx
@@ -34,7 +34,7 @@ export const chipsTwo = [
 
 <ImportPath component={Chip} section="interactive" />
 
-<Story name="Knobs">
+<Story name="Knobs" parameters={{ docs: { disable: true }}}>
   <Chip
     isActive={boolean("isActive", false)}
     label={text("label", "Hello World")}
@@ -47,6 +47,12 @@ export const chipsTwo = [
     theme={options("theme", THEMES, undefined, { display: "inline-radio" })}
   />
 </Story>
+
+<Preview isExpanded>
+  <Chip
+    label="Hello world"
+  />
+</Preview>
 
 <Props of={Chip} />
 

--- a/src/components/interactive/dropdownButton.stories.mdx
+++ b/src/components/interactive/dropdownButton.stories.mdx
@@ -14,8 +14,16 @@ import DropdownButton from "./DropdownButton";
 
 <ImportPath component={DropdownButton} section="interactive" />
 
+<Story name="Knobs" parameters={{ docs: { disable: true }}}>
+  <DropdownButton
+    isFullWidth={boolean("disabled", undefined)}
+  >
+    {text("children", 'DropdownButton')}
+  </DropdownButton>
+</Story>
+
 <Preview isExpanded>
-  <DropdownButton>Filter by Analyst</DropdownButton>
+  <DropdownButton>Dropdown Button</DropdownButton>
 </Preview>
 
 <Props of={DropdownButton} />
@@ -23,8 +31,10 @@ import DropdownButton from "./DropdownButton";
 DropDownButton will render any JSX passed to it
 
 <Preview>
-  <DropdownButton>
-    <span className="fontWeight--bold fontSize--default">Hello</span> world
-  </DropdownButton>
+  <Story name="JSX">
+    <DropdownButton>
+      <span className="fontWeight--bold fontSize--default">Hello</span> world
+    </DropdownButton>
+  </Story>
 </Preview>
 

--- a/src/components/interactive/floatingAction.stories.mdx
+++ b/src/components/interactive/floatingAction.stories.mdx
@@ -11,7 +11,7 @@ import FloatingAction, { VALID_FAB_THEMES } from './FloatingAction';
 
 <ImportPath component={FloatingAction} section="interactive" />
 
-<Story name="Knobs">
+<Story name="Knobs" parameters={{ docs: { disable: true }}}>
   <FloatingAction
     disabled={boolean('disabled', false)}
     isLoading={boolean('isLoading', false)}
@@ -22,6 +22,14 @@ import FloatingAction, { VALID_FAB_THEMES } from './FloatingAction';
     label={text("label", "Add Column")}
   />
 </Story>
+
+<Preview isExpanded>
+  <FloatingAction
+    Icon={ApproveIcon}
+    label="Add Column"
+  />
+</Preview>
+
 
 <Props of={FloatingAction} />
 

--- a/src/components/interactive/iconButton.stories.mdx
+++ b/src/components/interactive/iconButton.stories.mdx
@@ -18,7 +18,7 @@ export const Icons = [StarFilledIcon, CollectionPublicIcon, StoryAddIcon, WorkFa
 
 <ImportPath component={IconButton} section="interactive" />
 
-<Story name="Knobs">
+<Story name="Knobs" parameters={{ docs: { disable: true }}}>
   <IconButton
     isDestructive={boolean('isDestructive', false)}
     disabled={boolean('disabled', false)}
@@ -36,6 +36,12 @@ export const Icons = [StarFilledIcon, CollectionPublicIcon, StoryAddIcon, WorkFa
     Icon={StarFilledIcon}
   />
 </Story>
+
+<Preview isExpanded>
+  <IconButton
+    Icon={StarFilledIcon}
+  />
+</Preview>
 
 <Props of={IconButton} />
 

--- a/src/components/interactive/stackedButton.stories.mdx
+++ b/src/components/interactive/stackedButton.stories.mdx
@@ -17,7 +17,7 @@ import { ImportPath } from '../util/storybook';
 
 <ImportPath component={StackedButton} section="interactive" />
 
-<Story name="Knobs">
+<Story name="Knobs" parameters={{ docs: { disable: true }}}>
   <StackedButton
     disabled={boolean('disabled', false)}
     Icon={StarFilledIcon}
@@ -25,6 +25,13 @@ import { ImportPath } from '../util/storybook';
     hasCaret={boolean('hasCaret', false)}
   />
 </Story>
+
+<Preview isExpanded>
+  <StackedButton
+    Icon={StarFilledIcon}
+    label='Stacked Button'
+  />
+</Preview>
 
 <Props of={StackedButton} />
 

--- a/src/components/interactive/toast.stories.mdx
+++ b/src/components/interactive/toast.stories.mdx
@@ -18,7 +18,7 @@ import { ImportPath } from '../util/storybook';
 
 <ImportPath component={Toast} section="interactive" />
 
-<Story name="Knobs">
+<Story name="Knobs" parameters={{ docs: { disable: true }}}>
   <Toast
     content={text(
       'label',
@@ -52,6 +52,10 @@ import { ImportPath } from '../util/storybook';
     )}
   />
 </Story>
+
+<Preview isExpanded>
+  <Toast content="Toast" type="success" />
+</Preview>
 
 <Props of={Toast} />
 

--- a/src/components/layout/flex.stories.mdx
+++ b/src/components/layout/flex.stories.mdx
@@ -45,7 +45,7 @@ export const ConditionalItemsExample = (props) => (
 
 Flex is an abstraction of CSS flexbox that provides a subset of flexbox functionality. **A `Flex` should only contain `FlexItem` children**.
 
-<Story name="Knobs">
+<Story name="Knobs" parameters={{ docs: { disable: true }}}>
   <div style={parentStyle} className="debug--flex">
     <Flex
       direction={radios(

--- a/src/components/media/Avatar.stories.mdx
+++ b/src/components/media/Avatar.stories.mdx
@@ -15,7 +15,7 @@ export const bgColorOptions = options('bgColor', arrayToOptions(BG_COLORS), unde
 
 <ImportPath component={Avatar} section="media" />
 
-<Story name="Knobs">
+<Story name="Knobs" parameters={{ docs: { disable: true }}}>
   <StoryWrapper>
     <StoryItem>
       <Avatar
@@ -52,6 +52,11 @@ export const bgColorOptions = options('bgColor', arrayToOptions(BG_COLORS), unde
     </StoryItem>
   </StoryWrapper>
 </Story>
+
+<Preview isExpanded>
+  <Avatar name='Samuel Jackson' />
+</Preview>
+
 
 _Displaying an Avatar with an image, and without an image, for visualization purposes_
 

--- a/src/components/media/Badge.stories.mdx
+++ b/src/components/media/Badge.stories.mdx
@@ -10,7 +10,7 @@ import Badge, { SIZES } from './Badge';
 
 <ImportPath component={Badge} section="media" />
 
-<Story name="Badge">
+<Story name="Knobs" parameters={{ docs: { disable: true }}}>
   <Badge 
     label={text('label', 'Badge')} 
     size={options('size', arrayToOptions(SIZES), undefined, {
@@ -18,6 +18,12 @@ import Badge, { SIZES } from './Badge';
     })}
   />
 </Story>
+
+<Preview isExpanded>
+  <Badge 
+    label="Badge"
+  />
+</Preview>
 
 <Props of={Badge} />
 
@@ -27,7 +33,7 @@ import Badge, { SIZES } from './Badge';
   <Story name="Sizes">
     {SIZES.map(size => (
       <div className="margin--right--half display--inlineBlock">
-        <Badge size={size} label={`Size: ${size}`} />
+        <Badge size={size} label="Badge" />
       </div>
     ))}
   </Story>

--- a/src/components/media/countdownButton.stories.mdx
+++ b/src/components/media/countdownButton.stories.mdx
@@ -14,8 +14,12 @@ import CountdownButton from './CountdownButton';
 
 An icon button that shows a radial countdown animation immediately on mount.
 
-<Story name="Knobs">
+<Story name="Knobs" parameters={{ docs: { disable: true }}}>
   <CountdownButton duration={number('duration', 4000)} onClick={action('clicked')} />
 </Story>
+
+<Preview isExpanded>
+  <CountdownButton duration={4000} />
+</Preview>
 
 <Props of={CountdownButton} />

--- a/src/components/media/updatable.stories.mdx
+++ b/src/components/media/updatable.stories.mdx
@@ -15,11 +15,17 @@ import Updatable from './Updatable';
 
 Wraps children in an "updatable" container with a `message` displayed as a notification-style red bubble.
 
-<Story name="Knobs">
+<Story name="Knobs" parameters={{ docs: { disable: true }}}>
   <Updatable message={text('message', 42)}>
     <button>lorem ipsum</button>
   </Updatable>
 </Story>
+
+<Preview isExpanded>
+  <Updatable message="42">
+    <button>lorem ipsum</button>
+  </Updatable>
+</Preview>
 
 <Props of={Updatable} />
 

--- a/src/components/popovers/popover.stories.mdx
+++ b/src/components/popovers/popover.stories.mdx
@@ -28,7 +28,7 @@ import Button from '../interactive/Button';
 
 Base popover component. Bring your own trigger and popover content.
 
-<Story name="Knobs">
+<Story name="Knobs" parameters={{ docs: { disable: true }}}>
   <Popover
     trigger={<div className="margin--bottom"><Button label="Click Me" /></div>}
     position={options('Position', arrayToOptions(VALID_POSITIONS), 'bottom', {
@@ -53,6 +53,25 @@ Base popover component. Bring your own trigger and popover content.
     </div>
   </Popover>
 </Story>
+
+<Preview isExpanded>
+  <Popover
+    position='right'
+    alignment='start'
+    distance={4}
+    interactionMode='click'
+    transitionName="GrowFast"
+    trigger={<div className="margin--bottom"><Button label="Click Me" /></div>}
+  >
+    <div
+      className="padding--all" 
+      style={{ outline: '3px dotted red', background: "#FFFFFF" }}
+    >
+      popover content
+    </div>
+  </Popover>
+</Preview>
+
 
 ## What this component does
 

--- a/src/components/popovers/tooltip.stories.mdx
+++ b/src/components/popovers/tooltip.stories.mdx
@@ -11,12 +11,20 @@ import Tooltip from './Tooltip';
 
 <ImportPath component={Tooltip} section="popovers" />
 
-<Story name="Knobs">
+<Story name="Knobs" parameters={{ docs: { disable: true }}}>
   <Tooltip
     trigger={<p>ℹ️Hover Here!</p>}
     message={text('Message', 'lol, you are very bad at hovering!')}
     maxWidth={number('max width', 240)}
   />
 </Story>
+
+<Preview isExpanded height={100}>
+  <Tooltip
+    trigger={<p>ℹ️Hover Here!</p>}
+    message='lol, you are very bad at hovering!'
+    maxWidth={240}
+  />
+</Preview>
 
 <Props of={Tooltip} />


### PR DESCRIPTION
## Description
Add expanded snippets to all stories.

The only section I didn't add is for layouts... there's something about how I'd implement that, that just doesn't feel right to me. All of the component snippets so far are about "simplicity", but because the nature of layout components is to show complexity, I sort of don't know if it makes sense to just adapt the examples from the knobs into a story. There's just too much to unpack there and may be better suited to be addressed at a later time.

## Screenshots
<img width="1082" alt="Screen Shot 2020-03-11 at 3 05 33 PM" src="https://user-images.githubusercontent.com/52427513/76453749-c8efc100-63a9-11ea-8121-b8453f5dbc2b.png">

## Checklist
- [x] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [x] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**