### PR TITLE
apply dist-tag when publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,7 +84,7 @@ pipeline {
     stage('Publish npm packages') {
       steps {
         ansiColor('xterm') {
-          sh "docker run ${DOCKER_IMAGE_NAME} yarn publish --new-version=${VERSION} --access=public"
+          sh "docker run ${DOCKER_IMAGE_NAME} yarn publish --tag=${NPM_TAG} --new-version=${VERSION} --access=public"
         }
       }
     }


### PR DESCRIPTION
## Description
Only publish master with the dist-tag `latest`, all other branches published with the tag `beta`

## Checklist
(Not relevant for this change)