### PR TITLE
UIP-669: run lint suite on prepush

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged",
-      "pre-push": "yarn test"
+      "pre-push": "yarn lint && yarn test"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
## Description
We want to run the lint suite just in case we were no-verifying commits up until the push.

## Screenshots
N/A

## Checklist
N/A