### PR TITLE
UIP-644: remove bgColorOptions

### DIFF
--- a/src/components/media/Avatar.stories.mdx
+++ b/src/components/media/Avatar.stories.mdx
@@ -5,10 +5,6 @@ import { action } from '@storybook/addon-actions';
 
 import Avatar, { BG_COLORS, SIZES, RADII, INITIALS_LENGTH } from './Avatar';
 
-export const bgColorOptions = options('bgColor', arrayToOptions(BG_COLORS), undefined, {
-  display: 'inline-radio',
-});
-
 <Meta title="Components/Media/Avatar" decorators={[withKnobs]} component={Avatar} />
 
 # Avatar


### PR DESCRIPTION
## Description
This should stop the bgColor knob from from appearing on every single story: https://cbinsights.atlassian.net/browse/UIP-644

## Screenshots
N/A

## Checklist
N/A (mdx changes don't require us to do anything else)