### PR TITLE
UIP-722: added moment as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "jest": "^24.8.0",
     "lint-staged": "^8.1.7",
     "mdcss": "^1.5.2",
+    "moment": "^2.20",
     "pascal-case": "^2.0.1",
     "postcss": "^7.0.2",
     "postcss-cli": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10259,7 +10259,7 @@ mkdirp@^0.5.1, mkdirp@~0.5.1:
   dependencies:
     minimist "0.0.8"
 
-moment@^2.18.1:
+moment@^2.18.1, moment@^2.20:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==


### PR DESCRIPTION
## Description
There was a new change in DateInput which causes moment to run when the component is mounted, and because moment is a peer dependency, this throws an error. So I added it as a dev dependency.

## Screenshots
N/A

## Checklist
N/A

