### PR TITLE
[v8] UIP-646: Checkbox refactor (no Reach UI, replaces the other Checkbox PR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,9 @@ This is an example of a brief overview of the _Major_ or _Minor_ version changes
 
 ### **BREAKING CHANGES**
 
-#### `Thing` Component
-Component was updated / removed.
+#### Checkbox Component
+- `inputRef` removed (can now just use normal refs)
+- `indeterminate` was removed (indeterminate now lives on `checked` prop)
 
 ## [7.19] Updated IconButton
 

--- a/src/components/forms/__snapshots__/checkbox.test.js.snap
+++ b/src/components/forms/__snapshots__/checkbox.test.js.snap
@@ -1,110 +1,95 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Checkbox component matches snapshot (disabled) 1`] = `
-<div
-  className="fdsCheckable fdsCheckbox fdsCheckable--disabled"
+<label
+  className="fdsCheckable fdsCheckbox flush--bottom fdsCheckable--disabled"
 >
   <input
     className="media--xs"
     disabled={true}
-    id="mock-universal-unique-identifier"
     name="snapshot_checkbox"
+    onChange={[Function]}
     type="checkbox"
   />
-  <label
-    className="flush--bottom"
-    htmlFor="mock-universal-unique-identifier"
+  <span
+    aria-hidden={true}
+    className="fdsCheckable--icon"
+    style={
+      Object {
+        "pointerEvents": "none",
+      }
+    }
   >
-    <span
-      className="fdsCheckable-icon--checked"
-    >
-      <CheckFilledIcon
-        size="xs"
-      />
-    </span>
-    <span
-      className="fdsCheckable-icon--unchecked"
-    >
-      <CheckEmptyIcon
-        size="xs"
-      />
-    </span>
-    <span
-      className="padding--left--half"
-    >
-      Snapshot Label
-    </span>
-  </label>
-</div>
+    <CheckEmptyIcon
+      color="#a2a0a0"
+      size="xs"
+    />
+  </span>
+  <span
+    className="padding--left--half color--secondary"
+  >
+    Snapshot Label
+  </span>
+</label>
 `;
 
 exports[`Checkbox component matches snapshot (with label) 1`] = `
-<div
-  className="fdsCheckable fdsCheckbox"
+<label
+  className="fdsCheckable fdsCheckbox flush--bottom"
 >
   <input
     className="media--xs"
     disabled={false}
-    id="mock-universal-unique-identifier"
     name="snapshot_checkbox"
+    onChange={[Function]}
     type="checkbox"
   />
-  <label
-    className="flush--bottom"
-    htmlFor="mock-universal-unique-identifier"
+  <span
+    aria-hidden={true}
+    className="fdsCheckable--icon"
+    style={
+      Object {
+        "pointerEvents": "none",
+      }
+    }
   >
-    <span
-      className="fdsCheckable-icon--checked"
-    >
-      <CheckFilledIcon
-        size="xs"
-      />
-    </span>
-    <span
-      className="fdsCheckable-icon--unchecked"
-    >
-      <CheckEmptyIcon
-        size="xs"
-      />
-    </span>
-    <span
-      className="padding--left--half"
-    >
-      Snapshot Label
-    </span>
-  </label>
-</div>
+    <CheckEmptyIcon
+      color="rgba(64, 64, 64, 0.60)"
+      size="xs"
+    />
+  </span>
+  <span
+    className="padding--left--half"
+  >
+    Snapshot Label
+  </span>
+</label>
 `;
 
 exports[`Checkbox component matches snapshot (without label) 1`] = `
 <div
-  className="fdsCheckable fdsCheckbox"
+  className="fdsCheckable fdsCheckbox flush--bottom"
 >
   <input
     className="media--xs"
     disabled={false}
-    id="mock-universal-unique-identifier"
     name="snapshot_checkbox"
+    onChange={[Function]}
     type="checkbox"
   />
-  <label
-    className="flush--bottom"
-    htmlFor="mock-universal-unique-identifier"
+  <span
+    aria-hidden={true}
+    className="fdsCheckable--icon"
+    style={
+      Object {
+        "pointerEvents": "none",
+      }
+    }
   >
-    <span
-      className="fdsCheckable-icon--checked"
-    >
-      <CheckFilledIcon
-        size="xs"
-      />
-    </span>
-    <span
-      className="fdsCheckable-icon--unchecked"
-    >
-      <CheckEmptyIcon
-        size="xs"
-      />
-    </span>
-  </label>
+    <CheckEmptyIcon
+      color="rgba(64, 64, 64, 0.60)"
+      size="xs"
+    />
+  </span>
 </div>
 `;

--- a/src/components/forms/checkbox.stories.mdx
+++ b/src/components/forms/checkbox.stories.mdx
@@ -1,20 +1,19 @@
 import { Meta, Story, Preview, Props, Source } from "@storybook/addon-docs/blocks";
 import { withKnobs, text, boolean } from '@storybook/addon-knobs';
-import { Info, ImportPath } from '../util/storybook';
+import { Info, State, ImportPath } from 'components/util/storybook';
+import { action } from "@storybook/addon-actions";
 
 import Checkbox from './Checkbox';
 
 <Meta title="Components/Forms/Checkbox" decorators={[withKnobs]} component={Checkbox} />
 
 # Checkbox
-
 <ImportPath component={Checkbox} section="forms" />
 
-Uncontrolled custom checkbox component with optional label.
+Custom checkbox component.
 
 <Story name="Knobs" parameters={{ docs: { disable: true }}}>
   <Checkbox
-    indeterminate={boolean('indeterminate', false)}
     disabled={boolean('disabled', false)}
     name="knobs"
     label={text('label', 'I agree to receive spam')}
@@ -33,6 +32,8 @@ Uncontrolled custom checkbox component with optional label.
 </Info>
 
 <Props of={Checkbox} />
+
+Component is uncontrolled by default, but you can utilize the `checked` prop to turn it into a controlled component.
 
 ## Managing checked state
 
@@ -65,12 +66,11 @@ checkbox.
 
 ## Checkboxes without labels
 
-You can prevent the label from showing by setting `showLabel` to `false`.
-The value of the `label` prop will be used to set an ARIA attribute.
+You should always render a label, but you can bring your own
 
 <Preview>
   <Story name="Checkbox without label">
-    <Checkbox name="no-label" label="I don't have a label" showLabel={false} />
+    <Checkbox name="no-label" />
   </Story>
 </Preview>
 
@@ -82,7 +82,7 @@ checked.
 
 <Preview>
   <Story name="Indeterminate checkboxes">
-    <Checkbox indeterminate name="notsureif" label="Indeterminate checkbox" />
+    <Checkbox checked="mixed" name="notsureif" label="Indeterminate checkbox" />
   </Story>
 </Preview>
 
@@ -93,6 +93,34 @@ renders. Read the `checked` attribute of the event `currentTarget`.
 
 <Preview>
   <Story name="Reading the value of a Checkbox">
-    <Checkbox label="Option one" onChange={(e) => { console.log(e.currentTarget.checked) }} />
+    <Checkbox label="Option one" onChange={action('clicked')} />
+  </Story>
+</Preview>
+
+## Variations
+
+<Preview>
+  <Story name="Variations">
+    <>
+      <Checkbox label="Indeterminate" checked="mixed" />
+      <br />
+      <State
+        initialValue={true}
+        render={(value, setValue) => (
+          <Checkbox label="Controlled Checked" checked={value} onChange={() => setValue(!value)}/>
+        )}
+      />
+      <br />
+      <State
+        initialValue={false}
+        render={(value, setValue) => (
+          <Checkbox label="Controlled Unchecked" checked={value} onChange={() => setValue(!value)}/>
+        )}
+      />
+      <br />
+      <Checkbox label="Uncontrolled" />
+      <br />
+      <Checkbox label="Uncontrolled Default Checked" defaultChecked />
+    </>
   </Story>
 </Preview>

--- a/src/components/forms/checkbox.test.js
+++ b/src/components/forms/checkbox.test.js
@@ -3,11 +3,6 @@ import { shallow } from 'enzyme';
 
 import Checkbox from './Checkbox';
 
-// uuid will break snapshots, so we must mock it.
-//
-// look at me, i'm universally unique, I'm _soooooo special_
-jest.mock('uuid/v4', () => jest.fn().mockReturnValue('mock-universal-unique-identifier'));
-
 describe('Checkbox component', () => {
 
   it('matches snapshot (without label)', () => {

--- a/src/components/style/forms/checkable.css
+++ b/src/components/style/forms/checkable.css
@@ -19,49 +19,7 @@
   top: 0;
 }
 
-.fdsCheckable label {
-  /* contains checkbox icon and text label */
-  display: inline-flex;
-  align-items: center;
-}
-
-.fdsCheckable .fds-icon {
-  color: var(--font-color-secondary);
-}
-
-.fdsCheckable input:focus + label svg {
+.fdsCheckable input:focus + .fdsCheckable--icon svg {
   box-shadow: inset 0 0 0 3px var(--border-color-focusRing);
   transition: box-shadow 250ms var(--motion-easing-default);
-}
-
-.fdsCheckable input:checked + label svg {
-  fill: var(--color-blue);
-}
-
-.fdsCheckable--disabled :matches(label,svg) {
-  color: var(--font-color-hint) !important;
-  fill: var(--font-color-hint) !important;
-}
-
-/**
- * Icon switching
- *
- * Both icons for checked/unchecked state are rendered in
- * the DOM; we use checked state selectors on the `input`
- * element to determine which one to show
- */
-.fdsCheckable input + label .fdsCheckable-icon--checked {
-  display: none;
-}
-
-.fdsCheckable input:checked + label .fdsCheckable-icon--checked {
-  display: block;
-}
-
-.fdsCheckable input + label .fdsCheckable-icon--unchecked {
-  display: block;
-}
-
-.fdsCheckable input:checked + label .fdsCheckable-icon--unchecked {
-  display: none;
 }

--- a/src/components/style/forms/checkbox.css
+++ b/src/components/style/forms/checkbox.css
@@ -1,5 +1,6 @@
 /* stylelint-disable selector-max-combinators */
 /* stylelint-disable selector-max-compound-selectors */
+/* stylelint-disable selector-max-specificity */
 
 /**
  * Checkbox-specific styles.
@@ -10,10 +11,6 @@
   transform: translateY(-1px);
 }
 
-.fdsCheckbox input:focus + label svg {
+.fdsCheckbox input:focus + .fdsCheckable--icon svg {
   border-radius: var(--border-radius-default);
-}
-
-.fdsCheckbox input:indeterminate + label svg {
-  fill: var(--color-blue);
 }


### PR DESCRIPTION
## Description

The same as that other PR, with some differences:

- Actually works with refs (I forgot to forward refs on the other one... I would have also likely caught this had I started implementing on cbi-site)
- Reach
  - I realized that Reach's components, for the advanced style that we're using them in, don't handle logic, and only handle CSS.
  - We're not using any of that CSS.
  - Reach sort of messed up the focus styles.

## Screenshots
<!-- Add screenshots if applicable -->

## Checklist
- [ ] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [ ] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**