### PR TITLE
UIP-737: Fix button group focus styles

### DIFF
--- a/src/components/interactive/GroupButton.jsx
+++ b/src/components/interactive/GroupButton.jsx
@@ -3,9 +3,11 @@ import cx from 'classnames';
 import PropTypes from 'prop-types';
 import baseElement from 'util/baseElement';
 
+const WrapperComponent = (wrapperProps) => wrapperProps.children;
+
 export const GroupButton = (props) => {
   const {
-    Wrapper = (wrapperProps) => wrapperProps.children,
+    Wrapper = WrapperComponent,
     isActive,
     Icon,
     label,


### PR DESCRIPTION
## Description
https://cbinsights.github.io/form-design-system/fds-components/?path=/story/components-interactive-buttongroup--states

You'll notice that in this story on production, clicking through these does not render the focus style, even though you can still tab through them to show the focus style. This is because underneath the hood, the component is unnecessarily re-rendering due to an inline definition of the wrapper component in the default parameters. By bubbling that up into a discreet component, the component no longer gets fully blown away, and the focus style is maintained as a result.

## Screenshots
<img width="328" alt="Screen Shot 2020-04-16 at 10 32 25 AM" src="https://user-images.githubusercontent.com/52427513/79468945-9733d080-7fcd-11ea-90dc-1fbc5bfc58ab.png">

## Checklist
- [ ] Docs have been rebuilt (`yarn build:full`)
- [ ] All unit tests pass
- [ ] Snapshots have been updated
- [ ] No lint errors or warnings have been introduced
- [ ] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**