### PR TITLE
UIP-754: IconButton padding

### DIFF
--- a/src/components/interactive/__snapshots__/button.test.js.snap
+++ b/src/components/interactive/__snapshots__/button.test.js.snap
@@ -26,8 +26,8 @@ exports[`ButtonGroup component matches snapshot (default props) 1`] = `
 
 exports[`ButtonGroup component matches snapshot (set all props) 1`] = `
 <Button
-  IconLeft="Icon"
-  IconRight="Icon"
+  IconLeft={[Function]}
+  IconRight={[Function]}
   Link={[Function]}
   disabled={true}
   hasCaret={true}

--- a/src/components/interactive/button.test.js
+++ b/src/components/interactive/button.test.js
@@ -5,6 +5,8 @@ import Button from './Button';
 
 describe('ButtonGroup component', () => {
 
+  const Icon = () => null
+
   it('matches snapshot (default props)', () => {
     const component = mount(<Button label="Button" />);
     expect(component).toMatchSnapshot();
@@ -18,8 +20,8 @@ describe('ButtonGroup component', () => {
         isLoading
         isDestructive
         disabled
-        IconLeft={"Icon"}
-        IconRight={"Icon"}
+        IconLeft={Icon}
+        IconRight={Icon}
         isFullWidth
         theme='outlined'
         hasCaret

--- a/src/components/style/interactive/iconButton.css
+++ b/src/components/style/interactive/iconButton.css
@@ -7,6 +7,7 @@
   font-size: var(--font-size-xs);
   position: relative;
   line-height: normal;
+  padding: 0;
   user-select: none;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Description
There can sometimes be css on the page that can mess with our IconButton alignment (you can see the IconButton is misaligned in the modal in the screenshot). We can counter this by nullifying padding on IconButton. 

I'm interpreting this at a patch and not going to bump the minor.

## Screenshots
<img width="976" alt="Screen Shot 2020-04-22 at 4 28 44 PM" src="https://user-images.githubusercontent.com/52427513/80031556-e1c6b880-84b7-11ea-8db8-034db95eb474.png">

## Checklist
- [ ] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [x] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**