### PR TITLE
UIP-752: allow longer text in stacked button without wrapping

### DIFF
--- a/src/components/style/interactive/stackedButton.css
+++ b/src/components/style/interactive/stackedButton.css
@@ -11,7 +11,7 @@
   padding: var(--space-half);
   background-color: transparent;
   font-weight: 500;
-  max-width: 62px;
+  max-width: 70px;
   box-sizing: border-box;
   align-items: center;
   color: var(--button-primary-color);


### PR DESCRIPTION
## Description
This will allow the "Add Section" button to wrap, without changing collectionbuttons at all

## Screenshots
<img width="1176" alt="Screen Shot 2020-04-22 at 4 52 58 PM" src="https://user-images.githubusercontent.com/52427513/80032841-bfce3580-84b9-11ea-8fff-06bc5cf66382.png">

## Checklist
- [ ] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [ ] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**