### PR TITLE
add naming convention for component reference props:

### DIFF
--- a/contributing/naming-conventions.md
+++ b/contributing/naming-conventions.md
@@ -115,6 +115,13 @@ Always name rest props `rest`:
 +const Component = ({ foo, bar, ...rest})
 ```
 
+Props that accept a component _reference_ should be uppercase:
+
+```diff
+-icon={CloudIcon}
++ Icon={CloudIcon} // CloudIcon is a reference to the imported icon component
+```
+
 ## CSS classes
 In FDS, we follow a modified BEM naming convention. With our convention, hyphens carry the
 meaning for block-element relationships and underscores are reserved for conditional


### PR DESCRIPTION
It's a bit too late to write a good ADR on the decision background because I've lost a lot of my memory of this discussion.

Moving forward, we can take notes in the ADR format as we're debating the decision.

For this decision, I'll just add a naming convention note to contributing guidelines