### PR TITLE
add popoverProps to DateInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,11 @@ This is an example of a brief overview of the _Major_ or _Minor_ version changes
 
 ---
 
+## [8.7] Popover configuration in DateInput
+
+- Adds `popoverProps` to `DateInput` for user configuration of the popover that contains
+  the date picker
+
 ## [8.6] DateInput enhancements
 
 - Adds `minDate` and `maxDate` props to `Dateinput` for specifying a selectable date range

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@
 * Jenkins populates the patch version depending on the branch.
 */
 
-String VERSION = "8.6"
+String VERSION = "8.7"
 
 /* ---- DO NOT EDIT BELOW (unless you really know what you're doing) ---- */
 

--- a/src/components/forms/DateInput.jsx
+++ b/src/components/forms/DateInput.jsx
@@ -170,6 +170,7 @@ const DateInput = ({
   futureYears = 1,
   pastYears = 40,
   dateFormat = 'MDY',
+  popoverProps = {},
   defaultDate,
   onDateChange,
   label,
@@ -183,6 +184,9 @@ const DateInput = ({
   const [inputValue, setInputValue] = useState(
     defaultDate ? moment(defaultDate).format(DATE_FORMAT_MAP[dateFormat]) : ''
   );
+
+  // eslint-disable-next-line no-param-reassign
+  delete popoverProps.trigger;
 
   // If the dateFormat prop changes while the input has a user-entered value,
   // we want the value to change to reflect the new dateFormat
@@ -240,6 +244,7 @@ const DateInput = ({
           IconRight={DatePickerIcon}
         />
       }
+      {...popoverProps}
     >
       <div className="elevation--2 rounded--all bgColor--white">
         <DayPicker
@@ -293,6 +298,12 @@ DateInput.propTypes = {
 
   /** Label for input */
   label: PropTypes.string,
+
+  /**
+   * Object accepting any valid prop from `Popover`.
+   * The `trigger` prop can not be set.
+   */
+  popoverProps: PropTypes.object,
 };
 
 export default DateInput;

--- a/src/components/forms/dateInput.stories.mdx
+++ b/src/components/forms/dateInput.stories.mdx
@@ -71,3 +71,21 @@ event for extra validation if necessary.
     />
   </Story>
 </Preview>
+
+## Customizing the picker popover
+
+The `Popover` containing the date picker can be configured via `popoverProps`.
+Any valid `Popover` prop is accepted except for `trigger`, which the `DateInput` must
+control.
+
+In this exmaple, the `alignment` prop of the popover has been set so the picker is
+right-aligned.
+
+<Preview>
+  <Story name="Popover props">
+    <DateInput
+      onDateChange={action('change')}
+      popoverProps={{ alignment: 'end' }}
+    />
+  </Story>
+</Preview>


### PR DESCRIPTION
## Description
Adds `popoverProps` object prop to `DateInput`

## Screenshots
<img width="850" alt="Screen Shot 2020-06-03 at 10 48 17 AM" src="https://user-images.githubusercontent.com/231252/83651762-d7541000-a587-11ea-90c6-3fc8628ae0f8.png">


## Checklist
- [ ] Docs have been rebuilt (`yarn build:full`)
- [ ] All unit tests pass
- [ ] Snapshots have been updated
- [ ] No lint errors or warnings have been introduced
- [ ] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**

