### PR TITLE
UIP-742: popper upgrades

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,10 +152,11 @@
   },
   "version": "4.0.0",
   "dependencies": {
+    "@popperjs/core": "^2.4.1",
     "@reach/menu-button": "^0.8.2",
     "focus-trap-react": "^6.0.0",
     "raf-schd": "^4",
-    "react-popper": "^1.3.4",
+    "react-popper": "^2.2.3",
     "throttle-debounce": "^2.1.0",
     "uuid": "^3.3.3"
   },

--- a/src/components/popovers/Popover.jsx
+++ b/src/components/popovers/Popover.jsx
@@ -183,26 +183,27 @@ const Popover = React.forwardRef(
     const clonedTrigger = React.cloneElement(trigger, triggerProps);
 
     // https://popper.js.org/popper-documentation.html#modifiers
-    const popperModifiers = {
-      offset: {
+    const popperModifiers = [
+      {
+        name: 'offset',
         enabled: true,
-        offset: `0,${distance}`,
+        options: {
+          offset: [0, distance],
+        },
       },
-      preventOverflow: {
-        boundariesElement: 'viewport',
+      {
+        name: 'preventOverflow',
+        options: {
+          boundariesElement: 'viewport',
+        },
       },
-      computeStyle: {
-        // When gpuAcceleration is enabled, `react-popper` always
-        // positions content to top/left 0 and uses `translate3d` to
-        // nudge it into place.
-        //
-        // This can cause issues with CSS transitions because it sets
-        // `will-change: transform`, which forces transitions to also
-        // ease the `translate3d`, which causes an unintended
-        // "diagonal slide" effect as the content appears.
-        gpuAcceleration: false,
+      {
+        name: 'computeStyles',
+        options: {
+          gpuAcceleration: false, // true by default
+        },
       },
-    };
+    ];
 
     const contentStyle = {
       zIndex: FDS.ZINDEX_POPOVER,

--- a/src/components/popovers/__snapshots__/popover.test.js.snap
+++ b/src/components/popovers/__snapshots__/popover.test.js.snap
@@ -10,22 +10,18 @@ exports[`Popover component matches snapshot (default props) 1`] = `
 >
   <Manager>
     <Reference>
-      <InnerReference
-        setReferenceNode={[Function]}
+      <div
+        aria-expanded="false"
+        aria-haspopup="true"
       >
-        <div
-          aria-expanded="false"
-          aria-haspopup="true"
-        >
-          <div>
-            <button
-              onClick={[Function]}
-            >
-              trigger
-            </button>
-          </div>
+        <div>
+          <button
+            onClick={[Function]}
+          >
+            trigger
+          </button>
         </div>
-      </InnerReference>
+      </div>
     </Reference>
     <Portal
       containerInfo={<body />}

--- a/src/components/popovers/__snapshots__/tooltip.test.js.snap
+++ b/src/components/popovers/__snapshots__/tooltip.test.js.snap
@@ -26,35 +26,31 @@ exports[`Tooltip component matches snapshot (uses the right classes) 1`] = `
   >
     <Manager>
       <Reference>
-        <InnerReference
-          setReferenceNode={[Function]}
+        <div
+          aria-expanded="false"
+          aria-haspopup="true"
         >
-          <div
-            aria-expanded="false"
-            aria-haspopup="true"
-          >
-            <div>
-              <span
-                onKeyDown={[Function]}
-                onKeyUp={[Function]}
-                onMouseEnter={[Function]}
-                onMouseLeave={[Function]}
-                style={
-                  Object {
-                    "cursor": "help",
-                  }
+          <div>
+            <span
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              onMouseEnter={[Function]}
+              onMouseLeave={[Function]}
+              style={
+                Object {
+                  "cursor": "help",
                 }
-                tabIndex="1"
-              >
-                <Trigger>
-                  <p>
-                    trigger
-                  </p>
-                </Trigger>
-              </span>
-            </div>
+              }
+              tabIndex="1"
+            >
+              <Trigger>
+                <p>
+                  trigger
+                </p>
+              </Trigger>
+            </span>
           </div>
-        </InnerReference>
+        </div>
       </Reference>
       <Portal
         containerInfo={<body />}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2277,6 +2277,11 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@popperjs/core@^2.4.1":
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.1.tgz#8fea7d588b33e277d7252f3ea608787c5cabd8c8"
+  integrity sha512-hdRh4Xul0S4VVJz8/T2EXuaVGnRp+bC/AksVp2DGtmvE4X4OKYsiZC4H2PlZmVhJZT58KFb5+xIog8BE3hpiSA==
+
 "@reach/auto-id@^0.8.2":
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/@reach/auto-id/-/auto-id-0.8.2.tgz#ea33a29dd08d186585650754f983129492cd86ce"
@@ -12742,6 +12747,11 @@ react-fast-compare@^2.0.4:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
+react-fast-compare@^3.0.1:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
+  integrity sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA==
+
 react-focus-lock@^2.1.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.2.1.tgz#1d12887416925dc53481914b7cedd39494a3b24a"
@@ -12830,7 +12840,7 @@ react-popper-tooltip@^2.11.0:
     "@babel/runtime" "^7.9.2"
     react-popper "^1.3.7"
 
-react-popper@^1.3.4, react-popper@^1.3.7:
+react-popper@^1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-1.3.7.tgz#f6a3471362ef1f0d10a4963673789de1baca2324"
   integrity sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==
@@ -12841,6 +12851,14 @@ react-popper@^1.3.4, react-popper@^1.3.7:
     popper.js "^1.14.4"
     prop-types "^15.6.1"
     typed-styles "^0.0.7"
+    warning "^4.0.2"
+
+react-popper@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.3.tgz#33d425fa6975d4bd54d9acd64897a89d904b9d97"
+  integrity sha512-mOEiMNT1249js0jJvkrOjyHsGvqcJd3aGW/agkiMoZk3bZ1fXN1wQszIQSjHIai48fE67+zwF8Cs+C4fWqlfjw==
+  dependencies:
+    react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
 react-redux@^7.0.2:


### PR DESCRIPTION
## Description
Upgrade `react-popper` (and add `@popperjs/core` as it's a peer dependency of `react-popper` now). Not going to bump anything as this isn't either a bug, feature, or breaking change.

## Screenshots
N/A

## Checklist
- [x] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [ ] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**