### PR TITLE
UIP-826: Remove isInModal support from Menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This is an example of a brief overview of the _Major_ or _Minor_ version changes
 
 #### `MenuButton` Component
 - Now only accepts a `button` element, or a component that renders a `button` element as a trigger
+- `isInModal` is no longer accepted
 
 #### `Dialog` Component
 - `width` and `height` now do not accept numbers. You must pass the unit type (px, vh, etc). 

--- a/src/components/Menu/__snapshots__/menu.test.js.snap
+++ b/src/components/Menu/__snapshots__/menu.test.js.snap
@@ -478,10 +478,10 @@ exports[`Popover component matches snapshot (in modal) 1`] = `
         </div>
       </MenuButton>
       <MenuPopover
-        className="elevation--2 rounded--all bgColor--white fdsMenu--inModal"
+        className="elevation--2 rounded--all bgColor--white"
       >
         <Popover
-          className="elevation--2 rounded--all bgColor--white fdsMenu--inModal"
+          className="elevation--2 rounded--all bgColor--white"
           data-reach-menu=""
           data-reach-menu-popover=""
           hidden={true}
@@ -508,7 +508,7 @@ exports[`Popover component matches snapshot (in modal) 1`] = `
               containerInfo={
                 <reach-portal>
                   <div
-                    class="elevation--2 rounded--all bgColor--white fdsMenu--inModal"
+                    class="elevation--2 rounded--all bgColor--white"
                     data-reach-menu=""
                     data-reach-menu-popover=""
                     data-reach-popover=""
@@ -555,7 +555,7 @@ exports[`Popover component matches snapshot (in modal) 1`] = `
               }
             >
               <PopoverImpl
-                className="elevation--2 rounded--all bgColor--white fdsMenu--inModal"
+                className="elevation--2 rounded--all bgColor--white"
                 data-reach-menu=""
                 data-reach-menu-popover=""
                 hidden={true}
@@ -578,7 +578,7 @@ exports[`Popover component matches snapshot (in modal) 1`] = `
                 }
               >
                 <div
-                  className="elevation--2 rounded--all bgColor--white fdsMenu--inModal"
+                  className="elevation--2 rounded--all bgColor--white"
                   data-reach-menu=""
                   data-reach-menu-popover=""
                   data-reach-popover=""

--- a/src/components/Menu/index.jsx
+++ b/src/components/Menu/index.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import cx from 'classnames';
 import PropTypes from 'prop-types';
 import {
   Menu as ReachMenu,
@@ -8,17 +7,13 @@ import {
   MenuPopover as ReachMenuPopover,
 } from '@reach/menu-button';
 
-const Menu = ({ isDisabled = false, isInModal = false, children, trigger }) => {
+const Menu = ({ isDisabled = false, children, trigger }) => {
   if (isDisabled) return trigger;
 
   return (
     <ReachMenu>
       <ReachMenuButton as="div">{trigger}</ReachMenuButton>
-      <ReachMenuPopover
-        className={cx('elevation--2 rounded--all bgColor--white', {
-          'fdsMenu--inModal': isInModal,
-        })}
-      >
+      <ReachMenuPopover className="elevation--2 rounded--all bgColor--white">
         <ReachMenuItems>{children}</ReachMenuItems>
       </ReachMenuPopover>
     </ReachMenu>
@@ -35,9 +30,6 @@ Menu.propTypes = {
 
   /** Prevent trigger from opening menu */
   isDisabled: PropTypes.bool,
-
-  /** Sets `z-index` to `zindex-crazy` when inside a modal. */
-  isInModal: PropTypes.bool,
 };
 
 export default Menu;

--- a/src/components/style/modals/menu.css
+++ b/src/components/style/modals/menu.css
@@ -6,15 +6,6 @@
   z-index: var(--zindex-modal);
 }
 
-.fdsMenu--inModal {
-  /*
-   * The Reach portaled popover can not be configured to use
-   * a different positioning strategy, so we must set a high
-   * zindex to ensure the menu list can appear above modals.
-   */
-  z-index: var(--zindex-crazy);
-}
-
 [data-reach-menu-items] {
   border-width: 0;
   padding: 0;


### PR DESCRIPTION
## Description
This prop was instituted to get around a then not complete modal / popover strategy. Since it's release, we cleaned up the strategy so this should no longer be an issue, and we can now remove support for this prop.

## Screenshots
N/A

## Checklist
- [x] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [x] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**