### PR TITLE
UIP-853: adding aria-invalid for TextInput

### DIFF
--- a/src/components/TextInput/__snapshots__/textInput.test.js.snap
+++ b/src/components/TextInput/__snapshots__/textInput.test.js.snap
@@ -50,7 +50,6 @@ exports[`TextInput component matches snapshot (default) 1`] = `
     <DecoratedInput>
       <IconInput>
         <input
-          aria-invalid={false}
           aria-label="label"
           className="fdsTextInput"
           onChange={[Function]}

--- a/src/components/TextInput/__snapshots__/textInput.test.js.snap
+++ b/src/components/TextInput/__snapshots__/textInput.test.js.snap
@@ -19,6 +19,7 @@ exports[`TextInput component matches snapshot (all props) 1`] = `
         IconRight={[Function]}
       >
         <input
+          aria-invalid={true}
           aria-label="label"
           className="fdsTextInput error"
           onChange={[Function]}
@@ -49,6 +50,7 @@ exports[`TextInput component matches snapshot (default) 1`] = `
     <DecoratedInput>
       <IconInput>
         <input
+          aria-invalid={false}
           aria-label="label"
           className="fdsTextInput"
           onChange={[Function]}

--- a/src/components/TextInput/index.jsx
+++ b/src/components/TextInput/index.jsx
@@ -84,7 +84,7 @@ const TextInput = React.forwardRef(
                 {...props}
                 ref={ref}
                 aria-label={showLabel ? label : undefined}
-                aria-invalid={Boolean(errorText || hasError)}
+                aria-invalid={errorText || hasError ? true : undefined}
                 onChange={inputOnChange}
                 type={type}
                 className={cx('fdsTextInput', {

--- a/src/components/TextInput/index.jsx
+++ b/src/components/TextInput/index.jsx
@@ -84,6 +84,7 @@ const TextInput = React.forwardRef(
                 {...props}
                 ref={ref}
                 aria-label={showLabel ? label : undefined}
+                aria-invalid={Boolean(errorText || hasError)}
                 onChange={inputOnChange}
                 type={type}
                 className={cx('fdsTextInput', {


### PR DESCRIPTION
## Description
Adding `aria-invalid` when input is in error state (better accessibility, easier tests)

## Screenshots
N/A

## Checklist
- [ ] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [x] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**