### PR TITLE
UIP-842: add transform for FDS clients to change imports to destructured pattern

### DIFF
--- a/scripts/bash/transforms/destructured-fds-component-import.js
+++ b/scripts/bash/transforms/destructured-fds-component-import.js
@@ -1,0 +1,48 @@
+module.exports = (file, api) => {
+    const fdsComponentPath = "@cbinsights/fds/lib/components";
+
+    const j = api.jscodeshift; // alias the jscodeshift API
+    const root = j(file.source); // parse JS code into an AST
+  
+    // Find all single component imports
+    const findSingleImports = root.find(j.ImportDeclaration, (node) => (
+      node.source.value.startsWith(`${fdsComponentPath}/`)
+    ));
+  
+    // If there's no single component imports we never need to do anything
+    if (!findSingleImports.size()) return root.toSource();
+  
+    // There has to be a way to map this or something :(
+    const importArr = [];
+    findSingleImports.forEach((item) => {
+      importArr.push(j.importSpecifier(j.identifier(item.value.specifiers[0].local.name)));
+    });
+  
+    // Find destructured component import
+    const destructuredImport = root.find(j.ImportDeclaration, {
+      source: { value: fdsComponentPath }
+    });
+  
+    // If there's no existing destructured import,
+    if (!destructuredImport.size()) {
+      findSingleImports
+         // Find the first single import
+        .at(0)
+        // and construct the destructured import right before that line
+        .insertBefore(j.importDeclaration(importArr, j.stringLiteral(fdsComponentPath)));
+    }
+  
+    destructuredImport.forEach((statement) => {
+      j(statement).replaceWith(
+        j.importDeclaration(
+          [...statement.value.specifiers, ...importArr],
+          j.stringLiteral(statement.value.source.value)
+        )
+      );
+    });
+  
+    // Now that single imports have been added to destructured imports, remove the single ones.
+    findSingleImports.remove();
+  
+    return root.toSource({ quote: "single" });
+  };

--- a/scripts/bash/transforms/destructured-fds-icon-import.js
+++ b/scripts/bash/transforms/destructured-fds-icon-import.js
@@ -1,0 +1,47 @@
+module.exports = (file, api) => {
+
+    const path = "@cbinsights/fds/lib/icons/react";
+
+    const j = api.jscodeshift; // alias the jscodeshift API
+    const root = j(file.source); // parse JS code into an AST
+  
+    // Find all single component imports
+    const findSingleImports = root.find(j.ImportDeclaration, (node) => (
+      node.source.value.startsWith(`${path}/`)
+    ));
+  
+    // If there's no single component imports we never need to do anything
+    if (!findSingleImports.size()) return root.toSource();
+  
+    const mappedSingleImports = findSingleImports
+        .nodes()
+        .map((item) => j.importSpecifier(j.identifier(item.specifiers[0].local.name)));
+  
+    // Find destructured component import
+    const destructuredImport = root.find(j.ImportDeclaration, {
+      source: { value: path }
+    });
+  
+    // If there's no existing destructured import,
+    if (!destructuredImport.size()) {
+      findSingleImports
+         // Find the first single import
+        .at(0)
+        // and construct the destructured import right before that line
+        .insertBefore(j.importDeclaration(mappedSingleImports, j.stringLiteral(path)));
+    }
+  
+    destructuredImport.forEach((statement) => {
+      j(statement).replaceWith(
+        j.importDeclaration(
+          [...statement.value.specifiers, ...mappedSingleImports],
+          j.stringLiteral(statement.value.source.value)
+        )
+      );
+    });
+  
+    // Now that single imports have been added to destructured imports, remove the single ones.
+    findSingleImports.remove();
+  
+    return root.toSource({ quote: "single" });
+  };


### PR DESCRIPTION
## Description
This transforms single FDS package imports to destructured component package imports for (separate scripts):
- components
- react icons

I did some dry runs of running this on `cbi-site` and it's fully functional. I probably might leave it to someone else to run this on `cbi-site` in terms of when to run it, announcing it (and the resulting conflicts), and probably good in terms of knowledge sharing.

## Screenshots
Results of running both scripts:
<img width="1108" alt="Screen Shot 2020-07-15 at 8 30 50 AM" src="https://user-images.githubusercontent.com/52427513/87545147-87339780-c675-11ea-8ec0-832bb8caa057.png">

## Checklist
- [x] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [x] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**