### PR TITLE
UIP-931: add npm badge to intro stories documentation

### DIFF
--- a/src/components/intro.docs.stories.mdx
+++ b/src/components/intro.docs.stories.mdx
@@ -4,6 +4,8 @@ import { Meta } from "@storybook/addon-docs/blocks";
 
 ## **(FDS)** Form Design System (v9)
 
+[![npm](https://img.shields.io/npm/v/@cbinsights/fds.svg?label=Latest%20Version)](http://www.npmjs.com/package/@cbinsights/fds)
+
 https://github.com/cbinsights/form-design-system
 
 ## Contributing guidelines


### PR DESCRIPTION
## Description
Adding npm badge to intro document

## Screenshots
<img width="854" alt="Screen Shot 2020-09-16 at 6 12 22 PM" src="https://user-images.githubusercontent.com/708820/93397724-2c224a80-f848-11ea-8f59-143e5b89e694.png">

## Checklist
- [ ] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [x] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**

