### PR TITLE
UIP-930: fix vertical padding class

### DIFF
--- a/src/base-styles/helperClasses/spacing/spacing.css
+++ b/src/base-styles/helperClasses/spacing/spacing.css
@@ -167,7 +167,7 @@
 .padding--top--m,
 .padding--y--m,
 .padding--all--m,
-.padding-y { padding-top: var(--space-default); }
+.padding--y { padding-top: var(--space-default); }
 
 .padding--top--l,
 .padding--y--l,


### PR DESCRIPTION
## Description
`padding-y` should be `padding--y`

## Screenshots
N/A

## Checklist
- [ ] Docs have been rebuilt (`yarn build:full`)
- [ ] All unit tests pass
- [ ] Snapshots have been updated
- [ ] No lint errors or warnings have been introduced
- [ ] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**

