### PR TITLE
UIP-957: updated dictionary color swatches to remove double hex value

### DIFF
--- a/src/util/storybook-docs/ColorSwatch.jsx
+++ b/src/util/storybook-docs/ColorSwatch.jsx
@@ -31,9 +31,9 @@ export const ColorSwatch = (props) => {
   const { cssVar, jsVar } = props;
 
   const layouts = [
+    { value: hexName, position: 'bottomRight' },
     { value: jsVar, position: 'topRight' },
     { value: cssVar, position: 'topLeft' },
-    { value: hexName, position: 'bottomRight' },
   ];
 
   return (
@@ -61,7 +61,6 @@ export const ColorSwatch = (props) => {
           {!copiedText ? (
             <React.Fragment>
               <b className="swatchContainer-name">{colorName}</b>
-              <div className="swatchContainer-hex">{hexName}</div>
             </React.Fragment>
           ) : (
             <b>COPIED</b>


### PR DESCRIPTION
## Description
This updates our swatches per design feedback to remove double hex value

## Screenshots
<img width="937" alt="Screen Shot 2020-10-12 at 1 37 04 PM" src="https://user-images.githubusercontent.com/708820/95775227-05610380-0c90-11eb-9d31-c663e6ceea11.png">

## Checklist
- [ ] Docs have been rebuilt (`yarn build:full`)
- [ ] All unit tests pass
- [ ] Snapshots have been updated
- [ ] No lint errors or warnings have been introduced
- [ ] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**

