### PR TITLE
add script to count FDS imports in a given dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Command                    | Description
 `yarn snapshot-update`| Updates snapshots
 `yarn lint`           | Runs `eslint` on all js files
 `yarn precommit`      | Runs `lint-staged` to verify precommit hook will pass
+`yarn stats:css`      | Prints a regex used to search all current FDS CSS classes
+`yarn stats:imports <PATH>` | Searches `<PATH>` for FDS component imports and prints a report
 
 ### Docs
 Documentation is published to Github Pages from the `docs/` directory in `master`.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "precommit": "lint-staged",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "stats:css": "node ./scripts/node/util/getUtilityCLassNames.js && cat lib/stats/utilityClassRegex.txt"
+    "stats:css": "node ./scripts/node/util/getUtilityCLassNames.js && cat lib/stats/utilityClassRegex.txt",
+    "stats:imports": "node ./scripts/node/util/getImportCount.js"
   },
   "peerDependencies": {
     "classnames": "^2",
@@ -50,6 +51,7 @@
   "devDependencies": {
     "@babel/cli": "^7.10.4",
     "@babel/core": "^7.10.4",
+    "@babel/parser": "^7",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/plugin-transform-modules-commonjs": "^7.10.4",
     "@babel/plugin-transform-regenerator": "^7.10.4",

--- a/scripts/node/util/getImportCount.js
+++ b/scripts/node/util/getImportCount.js
@@ -1,0 +1,79 @@
+/**
+ * ---------------------------
+ * Provides a count of FDS component imports from a given repo
+ * ---------------------------
+ */
+
+
+const fs = require('fs');
+const glob = require('glob');
+const path = require('path');
+const parser = require('@babel/parser');
+
+if (!process.argv[2]) throw new Error('Missing target dir. Run `yarn stats:imports <TARGET_DIR>');
+
+const GLOB_PATTERN = `${path.resolve(process.argv[2])}/**/*.+(js|jsx)`;
+const FILENAME_DENYLIST = [
+  'node_modules',
+  '__tests__',
+  '__spec__',
+  '__snapshots__',
+];
+const FDS_IMPORT_SOURCE = '@cbinsights/fds';
+
+/**
+ * @param {String} path filepath
+ * @returns {Boolean} true if file contains an FDS import
+ */
+const hasFdsImport = (path) => fs.readFileSync(path).includes(FDS_IMPORT_SOURCE);
+
+/**
+ * @param {String} path filepath
+ * @returns {Object} AST for file
+ */
+const toAst = (path) => parser.parse(
+  fs.readFileSync(path).toString(),
+  {
+    sourceType: 'module',
+    plugins: [
+      'jsx',
+      'classProperties',
+    ],
+  }
+);
+
+/**
+ * @param {Object} ast file ast
+ * @returns {Array} list of FDS components imported in file
+ */
+const toComponentList = (ast) => ast.program.body
+  .filter((node) => node.type === 'ImportDeclaration')        // only imports
+  .filter((i) => i.source.value.includes(FDS_IMPORT_SOURCE))  // only FDS imports
+  .flatMap((i) => i.specifiers.map((s) => s.local.name));     // return a flat arr of local specifier names
+
+
+glob(GLOB_PATTERN, (error, files) => {
+  const componentCountMap = files
+    .filter((path) => !FILENAME_DENYLIST.some((word) => path.includes(word)))
+    .filter(hasFdsImport)       // only convert files that actually have FDS imports
+    .map(toAst)
+    .flatMap(toComponentList)   // get component names from each file and merge into flat arr
+    .reduce((acc,curr) => {     // count up the number of imports for each component in an obj
+      if (!acc[curr]) acc[curr] = 0;
+      acc[curr]++;
+      return acc;
+    }, {});
+
+  const totalImports = Object.values(componentCountMap)
+    .reduce((acc,curr) => acc + curr, 0);
+
+  const sortedCounts = Object.entries(componentCountMap)
+    .sort((a,b) => b[1] - a[1])
+    .map((arr) => `  ${arr[1]}       ${arr[0]}`);
+
+  console.log('\n IMPORTS    NAME');
+  console.log('----------------------------------');
+  sortedCounts.forEach((line) => console.log(line));
+  console.log(`\nsource: ${process.argv[2]}`);
+  console.log(` TOTAL: ${totalImports}`);
+});

--- a/scripts/node/util/getUtilityClassNames.js
+++ b/scripts/node/util/getUtilityClassNames.js
@@ -18,12 +18,12 @@ const { LIB_ROOT } = require('../constants');
  * These characters indicate a selector that is not a basic utility class
  * (combinators, attribute selectors, etc)
  */
-const SELECTOR_CHAR_BLACKLIST = [' ', ':', '+', '[']
+const SELECTOR_CHAR_DENYLIST = [' ', ':', '+', '[']
 
 /**
  * Exclude inverted. We get too many false positives.
  */
-const CLASSNAME_BLACKLIST = ['inverted'];
+const CLASSNAME_DENYLIST = ['inverted'];
 
 // Get CSS string from built file in `lib`
 const inputCss = fs.readFileSync(path.resolve(LIB_ROOT, 'base-styles/base-styles.full.css')).toString();
@@ -43,11 +43,11 @@ css.parse(inputCss).stylesheet.rules
 // get just the utility classes
 const utilityClasses = allSelectors
   .filter((s) => s[0] === '.')       // include only class selectors
-  .filter((s) =>                     // filter out blacklisted chars
-    !SELECTOR_CHAR_BLACKLIST.some((ch) => s.includes(ch))
+  .filter((s) =>                     // filter out denied chars
+    !SELECTOR_CHAR_DENYLIST.some((ch) => s.includes(ch))
   )
-  .filter((s) =>                     // filter out blacklisted classes
-    !CLASSNAME_BLACKLIST.some((classname) => s.includes(classname))
+  .filter((s) =>                     // filter out denied classes
+    !CLASSNAME_DENYLIST.some((classname) => s.includes(classname))
    )
   .map((s) => s.replace('.', ''));   // remove dot (we're checking usage, not definition)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -320,6 +320,11 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@babel/parser@^7":
+  version "7.12.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.0.tgz#2ad388f3960045b22f9b7d4bf85e80b15a1c9e3a"
+  integrity sha512-dYmySMYnlus2jwl7JnnajAj11obRStZoW9cG04wh4ZuhozDn11tDUrhHcUZ9iuNHqALAhh60XqNaYXpvuuE/Gg==
+
 "@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.10.5", "@babel/parser@^7.11.0", "@babel/parser@^7.11.1", "@babel/parser@^7.4.3", "@babel/parser@^7.7.0", "@babel/parser@^7.9.6":
   version "7.11.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.3.tgz#9e1eae46738bcd08e23e867bab43e7b95299a8f9"
@@ -4549,7 +4554,7 @@ commander@^2.14.1, commander@^2.19.0, commander@^2.20.0, commander@^2.9.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^4.0.1, commander@^4.1.1:
+commander@^4.0.1, commander@^4.1.0, commander@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
@@ -12350,6 +12355,13 @@ schema-utils@^2.6.5, schema-utils@^2.6.6, schema-utils@^2.7.0:
     "@types/json-schema" "^7.0.4"
     ajv "^6.12.2"
     ajv-keywords "^3.4.1"
+
+search-in-file@^1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/search-in-file/-/search-in-file-1.2.2.tgz#259f72247cdf66d3ad3d63ac450d0a703cd1cb19"
+  integrity sha512-6mqEn/nAwuewdyTrry487RPB14ciy9JS45bBop4SNgYTPOOgXcW3JRzloeMwJ1GnxZyG4ylbf1Tzmtk3DqKFlA==
+  dependencies:
+    commander "^4.1.0"
 
 select@^1.1.2:
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4554,7 +4554,7 @@ commander@^2.14.1, commander@^2.19.0, commander@^2.20.0, commander@^2.9.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^4.0.1, commander@^4.1.0, commander@^4.1.1:
+commander@^4.0.1, commander@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
@@ -12355,13 +12355,6 @@ schema-utils@^2.6.5, schema-utils@^2.6.6, schema-utils@^2.7.0:
     "@types/json-schema" "^7.0.4"
     ajv "^6.12.2"
     ajv-keywords "^3.4.1"
-
-search-in-file@^1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/search-in-file/-/search-in-file-1.2.2.tgz#259f72247cdf66d3ad3d63ac450d0a703cd1cb19"
-  integrity sha512-6mqEn/nAwuewdyTrry487RPB14ciy9JS45bBop4SNgYTPOOgXcW3JRzloeMwJ1GnxZyG4ylbf1Tzmtk3DqKFlA==
-  dependencies:
-    commander "^4.1.0"
 
 select@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## Description
Adds script to make it easier to collect component adoption metric with v9 style imports

## example output

```
 IMPORTS    NAME
----------------------------------
  7       TrashIcon
  5       FDS
  5       AddIcon
  4       DenyIcon
  3       ActionsArrowDownIcon
  3       SearchIcon
  2       ActionsArrowUpIcon
  2       CheckIcon
  2       IconButton
  1       Popover
  1       CloudIcon
  1       CheckEmptyIcon
  1       CheckFilledIcon
  1       OneWay
  1       TwoWay
  1       ApproveIcon
  1       UpdateIcon
  1       StarEmptyIcon
  1       CircleCloseIcon
  1       CaretDownIcon
  1       CaretUpIcon
  1       InformationIcon
  1       NavArrowDownIcon
  1       NavArrowUpIcon

source: ../admin-frontend-service/
 TOTAL: 48
```

## Checklist
- [x] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [x] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**

