### PR TITLE
UIP-635: breakout links

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 variables:
   CBI_NODE_VERSION: "node:12-alpine"
   CBI_MAJOR_VERSION: 9
-  CBI_MINOR_VERSION: 17
+  CBI_MINOR_VERSION: 18
 
 include:
   - project: 'engineering/gitlab-includes'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ This is an example of a brief overview of the _Major_ or _Minor_ version changes
 
 ---
 
+## [9.18] Breakout Links
+
+- Added `breakoutLink` class (to extend clickable area to nearest relative parent)
+- Added `isBreakoutLink` props to `Button` and `IconButton` components to apply 
+the `breakoutLink` class
+
 ## [9.17] Added ZeroState component
 - Added `ZeroState` component, useful for displaying when a lack of the primary UI isn't available (due to lack of results, columns, etc)
 

--- a/src/base-styles/helperClasses/links/breakout.css
+++ b/src/base-styles/helperClasses/links/breakout.css
@@ -1,0 +1,8 @@
+.breakoutLink::after {
+  content: "";
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
+}

--- a/src/base-styles/helperClasses/links/links.stories.mdx
+++ b/src/base-styles/helperClasses/links/links.stories.mdx
@@ -31,7 +31,7 @@ export const TypeLink = () => (
   isCSS
   headers={['class', 'description', 'sample']}
   rows={[
-    ['breakoutLink', 'Allow button to extend to the bounds of the nearest position relative element. https://css-tricks.com/breakout-buttons/', {children: <Breakout /> }],
+    ['breakoutLink', 'Allows a button or link to extend to the bounds of the nearest position relative element. https://css-tricks.com/breakout-buttons/', {children: <Breakout /> }],
     ['type--link', 'Allows you to make buttons or text look like a link', { children: <TypeLink /> }],
   ]} 
 />

--- a/src/base-styles/helperClasses/links/links.stories.mdx
+++ b/src/base-styles/helperClasses/links/links.stories.mdx
@@ -1,0 +1,37 @@
+import { Meta, Story } from "@storybook/addon-docs/blocks";
+import { Example, generalStyles, containerStyles, layoutStyle, labelStyle } from 'base-styles/styledocUtils';
+import { TableLayout } from 'util/storybook-docs/Table';
+import State from 'util/storybook-docs/State';
+
+<Meta title="Style Utilities/Links"  />
+
+export const Breakout = () => (
+  <div className="alignChild--center--center" style={{ border: "1px dashed #f09", width: "200px", height: "200px", position: "relative" }}>
+    <State
+      initialValue={true}
+      render={(value, setValue) => (
+        <button className="breakoutLink" onClick={() => setValue(!value)}>
+          Breakout Button {value ? "Off" : "On"}
+        </button>
+      )}
+    >
+    </State>
+  </div>
+)
+
+export const TypeLink = () => (
+  <button className="resetButton type--link" onClick={() => window.alert('Terms of service.')}>
+    Link
+  </button>
+)
+
+# Links
+
+<TableLayout
+  isCSS
+  headers={['class', 'description', 'sample']}
+  rows={[
+    ['breakoutLink', 'Allow button to extend to the bounds of the nearest position relative element. https://css-tricks.com/breakout-buttons/', {children: <Breakout /> }],
+    ['type--link', 'Allows you to make buttons or text look like a link', { children: <TypeLink /> }],
+  ]} 
+/>

--- a/src/base-styles/index.css
+++ b/src/base-styles/index.css
@@ -44,6 +44,9 @@
 /* List Helpers */
 @import "./helperClasses/list/decorated";
 
+/* Link Helpers */
+@import "./helperClasses/links/breakout";
+
 /* Typesetting */
 @import "./helperClasses/typeset/scale";
 @import "./helperClasses/typeset/links";

--- a/src/components/Button/index.jsx
+++ b/src/components/Button/index.jsx
@@ -22,6 +22,7 @@ const Button = forwardRef(
       isDestructive,
       isFullWidth,
       hasCaret,
+      isBreakoutLink,
       ...rest
     },
     ref
@@ -71,6 +72,7 @@ const Button = forwardRef(
             'fdsButton--disabled': disabled,
             'fdsButton--isFullWidth': isFullWidth,
             'fdsButton--isActive': isActive && !disabled,
+            breakoutLink: isBreakoutLink,
           },
           'fdsButton',
           'fontStyle--caps',
@@ -84,15 +86,18 @@ const Button = forwardRef(
         ])}
         disabled={disabled && Element === 'button'}
       >
-        <span className={cc([{ 'fdsButton--hidden': isLoading }, 'fdsButton-label'])}>
-          {label}
-        </span>
-        <Icons />
-        {hasCaret && (
-          <div className="margin--left--half alignChild--center--center">
-            <CaretDownIcon customSize={12} />
-          </div>
-        )}
+        <div className="display--inlineFlex fdsButton--loading-spinnerWrapper">
+          <div className={cc({ 'fdsButton--loading-spinner': isLoading })} />
+          <span className={cc([{ 'fdsButton--hidden': isLoading }, 'fdsButton-label'])}>
+            {label}
+          </span>
+          <Icons />
+          {hasCaret && (
+            <div className="margin--left--half alignChild--center--center">
+              <CaretDownIcon customSize={12} />
+            </div>
+          )}
+        </div>
       </Element>
     );
   }
@@ -143,6 +148,8 @@ Button.propTypes = {
    * - `Link={Link}`
    */
   Link: PropTypes.func,
+  /** Extend click radius of button to nearest relative parent */
+  isBreakoutLink: PropTypes.bool,
 };
 
 export default Button;

--- a/src/components/Button/index.stories.js
+++ b/src/components/Button/index.stories.js
@@ -216,6 +216,27 @@ Loading.parameters = {
   },
 };
 
+export const Breakout = (args) => (
+  <StoryWrapper>
+    <StoryItem>
+      <div
+        className="alignChild--center--center"
+        style={{ padding: '20px', border: '1px dashed #f09', position: 'relative' }}
+      >
+        <Button {...args} label="Button" isBreakoutLink />
+      </div>
+    </StoryItem>
+  </StoryWrapper>
+);
+
+Breakout.parameters = {
+  docs: {
+    description: {
+      story: 'Breakout buttons extend their clickable area to the next nearest parent.',
+    },
+  },
+};
+
 export const Misc = () => (
   <div style={{ width: '100px' }}>
     <Button label="Text can wrap" />

--- a/src/components/Button/index.stories.js
+++ b/src/components/Button/index.stories.js
@@ -220,8 +220,8 @@ export const Breakout = (args) => (
   <StoryWrapper>
     <StoryItem>
       <div
-        className="alignChild--center--center"
-        style={{ padding: '20px', border: '1px dashed #f09', position: 'relative' }}
+        className="alignChild--center--center padding--all--xl"
+        style={{ border: '1px dashed #f09', position: 'relative' }}
       >
         <Button {...args} label="Button" isBreakoutLink />
       </div>

--- a/src/components/Button/index.test.js
+++ b/src/components/Button/index.test.js
@@ -42,12 +42,14 @@ describe('Button component', () => {
         isLoading	
         disabled	
         isFullWidth	
+        isBreakoutLink
       />
     );
     const button = screen.getByRole('button', { name: "Button" });
     expect(button).toHaveClass('fdsButton--disabled');
     expect(button).toHaveClass('fdsButton--loading');
     expect(button).toHaveClass('fdsButton--isFullWidth');
+    expect(button).toHaveClass('breakoutLink');
   });
 
 });

--- a/src/components/IconButton/__snapshots__/index.test.js.snap
+++ b/src/components/IconButton/__snapshots__/index.test.js.snap
@@ -5,6 +5,13 @@ exports[`ButtonGroup component matches snapshot (default props) 1`] = `
   className="fdsIconButton rounded--all border--focus--noTransition transition--default alignChild--center--center fdsIconButton--ghost fdsIconButton--m"
   title="Label"
 >
+  <div
+    className="fdsIconButton--loading-spinnerWrapper"
+  >
+    <div
+      className=""
+    />
+  </div>
   <span
     className=""
   >
@@ -21,6 +28,13 @@ exports[`ButtonGroup component matches snapshot (set all props) 1`] = `
   disabled={true}
   title="Label"
 >
+  <div
+    className="fdsIconButton--loading-spinnerWrapper"
+  >
+    <div
+      className="fdsIconButton--loading-spinner"
+    />
+  </div>
   <span
     className="fdsIconButton--hidden"
   >

--- a/src/components/IconButton/index.jsx
+++ b/src/components/IconButton/index.jsx
@@ -20,6 +20,7 @@ const IconButton = forwardRef(
       isDestructive,
       label,
       Link,
+      isBreakoutLink,
       ...rest
     },
     ref
@@ -37,6 +38,7 @@ const IconButton = forwardRef(
             'fdsIconButton--isActive': isActive && !disabled,
             'fdsIconButton--isDestructive': isDestructive,
             'fdsIconButton--loading': isLoading,
+            breakoutLink: isBreakoutLink,
           },
           'fdsIconButton',
           'rounded--all',
@@ -48,6 +50,9 @@ const IconButton = forwardRef(
         ])}
         disabled={disabled && Element === 'button'}
       >
+        <div className="fdsIconButton--loading-spinnerWrapper">
+          <div className={cc({ 'fdsIconButton--loading-spinner': isLoading })} />
+        </div>
         <span className={isLoading ? 'fdsIconButton--hidden' : ''}>
           <Icon customSize={size === 's' ? 16 : 18} />
         </span>
@@ -86,6 +91,8 @@ IconButton.propTypes = {
   Icon: PropTypes.func.isRequired,
   /** Accessibility label */
   label: PropTypes.string.isRequired,
+  /** Extend click radius of button to nearest relative parent */
+  isBreakoutLink: PropTypes.bool,
 };
 
 export default IconButton;

--- a/src/components/IconButton/index.stories.js
+++ b/src/components/IconButton/index.stories.js
@@ -137,8 +137,8 @@ export const Breakout = (args) => (
   <StoryWrapper>
     <StoryItem>
       <div
-        className="alignChild--center--center"
-        style={{ padding: '20px', border: '1px dashed #f09', position: 'relative' }}
+        className="alignChild--center--center padding--all--xl"
+        style={{ border: '1px dashed #f09', position: 'relative' }}
       >
         <IconButton {...args} {...Primary.args} isBreakoutLink />
       </div>

--- a/src/components/IconButton/index.stories.js
+++ b/src/components/IconButton/index.stories.js
@@ -133,6 +133,27 @@ export const Radii = (args) => (
   </StoryWrapper>
 );
 
+export const Breakout = (args) => (
+  <StoryWrapper>
+    <StoryItem>
+      <div
+        className="alignChild--center--center"
+        style={{ padding: '20px', border: '1px dashed #f09', position: 'relative' }}
+      >
+        <IconButton {...args} {...Primary.args} isBreakoutLink />
+      </div>
+    </StoryItem>
+  </StoryWrapper>
+);
+
+Breakout.parameters = {
+  docs: {
+    description: {
+      story: 'Breakout buttons extend their clickable area to the next nearest parent.',
+    },
+  },
+};
+
 export const Loading = (args) => (
   <StoryWrapper>
     <StoryItem>

--- a/src/components/Toaster/__snapshots__/index.test.js.snap
+++ b/src/components/Toaster/__snapshots__/index.test.js.snap
@@ -111,6 +111,13 @@ exports[`Toaster component matches snapshot 1`] = `
                               class="shape--circle fdsIconButton rounded--all border--focus--noTransition transition--default alignChild--center--center fdsIconButton--ghost fdsIconButton--m"
                               title="Close"
                             >
+                              <div
+                                class="fdsIconButton--loading-spinnerWrapper"
+                              >
+                                <div
+                                  class=""
+                                />
+                              </div>
                               <span
                                 class=""
                               >
@@ -354,6 +361,13 @@ exports[`Toaster component matches snapshot 1`] = `
                                             className="shape--circle fdsIconButton rounded--all border--focus--noTransition transition--default alignChild--center--center fdsIconButton--ghost fdsIconButton--m"
                                             title="Close"
                                           >
+                                            <div
+                                              className="fdsIconButton--loading-spinnerWrapper"
+                                            >
+                                              <div
+                                                className=""
+                                              />
+                                            </div>
                                             <span
                                               className=""
                                             >

--- a/src/components/style/button.css
+++ b/src/components/style/button.css
@@ -6,7 +6,6 @@
   letter-spacing: 1px;
   font-weight: var(--font-weight-medium);
   font-size: var(--font-size-default);
-  position: relative;
   line-height: normal;
   user-select: none;
   /* We do this to make sure buttons with borders and without are the same dimensions */
@@ -53,7 +52,11 @@
   }
 }
 
-.fdsButton--loading::before {
+.fdsButton--loading-spinnerWrapper {
+  position: relative;
+}
+
+.fdsButton--loading-spinner::before {
   content: "";
   position: absolute;
   top: 50%;
@@ -192,7 +195,7 @@
   background-color: rgba(229, 50, 62, 0.2);
 }
 
-.fdsButton--loading:matches(.fdsButton--ghost, .fdsButton--outlined)::before {
+.fdsButton--loading:matches(.fdsButton--ghost, .fdsButton--outlined) .fdsButton--loading-spinner::before {
   border: 2px solid #5DABCB;
   border-top-color: transparent;
 }
@@ -236,8 +239,8 @@
 }
 
 /* stylelint-disable-next-line selector-max-class */
-.inverted .fdsButton--ghost.fdsButton--loading::before,
-.inverted .fdsButton--outlined.fdsButton--loading::before {
+.inverted .fdsButton--ghost .fdsButton--loading-spinner::before,
+.inverted .fdsButton--outlined .fdsButton--loading-spinner::before {
   border: 2px solid var(--color-white);
   border-top-color: transparent;
 }
@@ -258,7 +261,7 @@
   border-color: var(--color-red);
 }
 
-.fdsButton--isDestructive:matches(.fdsButton--outlined, .fdsButton--ghost)::before {
+.fdsButton--isDestructive:matches(.fdsButton--outlined, .fdsButton--ghost) .fdsButton--loading-spinner::before {
   border: 2px solid var(--color-red);
   border-top-color: transparent;
 }

--- a/src/components/style/iconButton.css
+++ b/src/components/style/iconButton.css
@@ -5,7 +5,6 @@
 .fdsIconButton {
   border: 0 none;
   font-size: var(--font-size-xs);
-  position: relative;
   line-height: normal;
   padding: 0;
   user-select: none;
@@ -162,7 +161,11 @@
   }
 }
 
-.fdsIconButton--loading::before {
+.fdsIconButton--loading-spinnerWrapper {
+  position: relative;
+}
+
+.fdsIconButton--loading-spinner::before {
   content: "";
   box-sizing: border-box;
   position: absolute;
@@ -179,7 +182,7 @@
 }
 
 
-.fdsIconButton--loading.fdsIconButton--isDestructive::before {
+.fdsIconButton--isDestructive .fdsIconButton--loading-spinner::before {
   border-color: var(--color-red);
   border-top-color: transparent;
 }


### PR DESCRIPTION
## Description
Add back breakout links
- Button
- IconButton
- reusable .breakoutLink class

## Screenshots
<img width="789" alt="Screen Shot 2020-11-05 at 2 42 18 PM" src="https://user-images.githubusercontent.com/708820/98288684-35d94c00-1f75-11eb-95e7-2df545532e22.png">
<img width="221" alt="Screen Shot 2020-11-05 at 2 42 29 PM" src="https://user-images.githubusercontent.com/708820/98288687-383ba600-1f75-11eb-8558-cf1c1ed337cd.png">

## Checklist
- [ ] Docs have been rebuilt (`yarn build:full`)
- [ ] All unit tests pass
- [ ] Snapshots have been updated
- [ ] No lint errors or warnings have been introduced
- [ ] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**

