### PR TITLE
🐛 make negating border class important

### DIFF
--- a/src/base-styles/helperClasses/border/sides.css
+++ b/src/base-styles/helperClasses/border/sides.css
@@ -21,7 +21,7 @@ class            | description
 }
 
 .border--none {
-  border-width: 0;
+  border-width: 0 !important;
 }
 
 .border--top {


### PR DESCRIPTION
## Description

This will be a patch version.

The spacing negation classes `flush--<direction>` are `!important`, based on the assumption it should override any other spacing classes applied.

The border negation class however, was not `!important`. This change fixes the issue.

## Checklist
- [x] Docs have been rebuilt (`yarn build:full`)
- [x] All unit tests pass
- [x] Snapshots have been updated
- [x] No lint errors or warnings have been introduced
- [x] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**

