### PR TITLE
add flush documentation back

### DIFF
--- a/src/base-styles/helperClasses/index.stories.mdx
+++ b/src/base-styles/helperClasses/index.stories.mdx
@@ -693,6 +693,26 @@ export const SpacingExample = ({ className }) => (
   </>
 </Story>
 
+## Flush
+
+Removes spacing from the given side of an element. Sets both `padding` and `margin` to `0`;
+
+<Story name="Flush">
+  <>
+    <TableLayout
+      isCSS
+      headers={['class', 'description']}
+      rows={[
+        ['flush--top', 'Removes top spacing from element'],
+        ['flush--right', 'Removes right spacing from element'],
+        ['flush--bottom', 'Removes bottom spacing from element'],
+        ['flush--left', 'Removes left spacing from element'],
+        ['flush--all', 'Removes spacing from all sides of an element'],
+      ]}
+    />
+  </>
+</Story>
+
 ## Elevation
 
 <TableLayout


### PR DESCRIPTION
## Description

Add Flush documentation back

(was mistakenly deleted when old spacing documentation was removed)

## Screenshots

<img width="1021" alt="Screen Shot 2021-03-03 at 1 53 25 PM" src="https://user-images.githubusercontent.com/708820/109863920-d68bff80-7c27-11eb-9683-6319b34d82fe.png">

## Checklist

N/A