### PR TITLE
UIP-1032: remove classnames peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "stats:imports": "node ./scripts/node/util/getImportStats.js"
   },
   "peerDependencies": {
-    "classnames": "^2",
     "dayjs": "^1.9.7",
     "prop-types": "^15",
     "raf-schd": "^4",


### PR DESCRIPTION
## Description

We no longer depend on classnames.

## Screenshots

N/A