### PR TITLE
UIP-1073: add package that throws errors on prop type warnings when running tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   rootDir: './',
   testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/lib/'],
-  setupFilesAfterEnv: ['<rootDir>/scripts/node/setupTests.js'],
+  setupFilesAfterEnv: ['<rootDir>/scripts/node/setupTests.js', 'jest-prop-type-error'],
   snapshotSerializers: ['<rootDir>/node_modules/enzyme-to-json/serializer'],
 };

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "handlebars": "^4.0.12",
     "husky": "^1.0.0-rc.13",
     "jest": "^26.6.3",
+    "jest-prop-type-error": "^1.1.0",
     "lint-staged": "^10.2.9",
     "pascal-case": "^2.0.1",
     "postcss": "^8.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9046,6 +9046,11 @@ jest-pnp-resolver@^1.2.2:
   resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz#b704ac0ae028a89108a4d040b3f919dfddc8e33c"
   integrity sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==
 
+jest-prop-type-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/jest-prop-type-error/-/jest-prop-type-error-1.1.0.tgz#7949a73cef6b9769ed9811139933b4139d2d8ad9"
+  integrity sha512-i/4hdbKSp6cFJc2z3Blu2WEOGjxbQ76pShhtDFIqUfdC8ruMGT57EOsBtBq69FVg915MUMwENNc185ejs7mmtg==
+
 jest-regex-util@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-24.9.0.tgz#c13fb3380bde22bf6575432c493ea8fe37965636"


### PR DESCRIPTION
## Description

We recently had a situation where a proptype was incorrect in FDS: https://github.com/cbinsights/form-design-system/pull/658.

This proptype was throwing an error in `cbi-site`. It was throwing in `form-design-system` tests but it was an optional warning. Given that `cbi-site` throws errors on proptypes in test, we should throw errors on proptypes in tests.

## Screenshots

N/A

## Checklist

N/A