### PR TITLE
Rename text class sections so that they are more closely linked in name

### DIFF
--- a/src/base-styles/helperClasses/index.stories.mdx
+++ b/src/base-styles/helperClasses/index.stories.mdx
@@ -894,13 +894,13 @@ Modifies the font family of text.
   />
 </Story>
 
-## Color Modifiers
+## Text Colors - Standard
 
 Modifies color of text.
 When using standard text color classes (`heading`, `primary`, `secondary`, `hint`),
 a parent element with the `inverted` class will switch the text to tints of white.
 
-<Story name="Color Modifiers">
+<Story name="Text Colors - Standard">
   <TableLayout
     isCSS
     headers={['class', 'description', 'color', 'inverted']}
@@ -924,11 +924,11 @@ a parent element with the `inverted` class will switch the text to tints of whit
   />
 </Story>
 
-## Fancy Text Colors
+## Text Colors - Extra
 
 If you don't see the color you need here, please make a request for it!
 
-<Story name="Fancy Text Colors">
+<Story name="Text Colors - Extra">
   <TableLayout
     isCSS
     headers={['class', 'description', 'color']}


### PR DESCRIPTION
## Description

The original goal for this ask was to combine these both one story. You can't really mix react and markdown though inside a story. You also can't use Storybook Doc Blocks Header, because doc block components break in Canvas view, and I didn't know if introducing custom css to display a header was the right decision. 

Solution: rename both sections so the relationship is clear and people can still find both easily.

## Screenshots

<img width="224" alt="Screen Shot 2021-05-28 at 10 19 14 AM" src="https://user-images.githubusercontent.com/708820/120006100-2a478400-bf9e-11eb-9fc6-baeadf0abd0e.png">

## Checklist

- [ ] Docs have been rebuilt (`yarn build:full`)
- [ ] All unit tests pass
- [ ] Snapshots have been updated
- [ ] No lint errors or warnings have been introduced
- [ ] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**
