### PR TITLE
add prettier check to CI

### DIFF
--- a/.github/workflows/reusable-linting.yml
+++ b/.github/workflows/reusable-linting.yml
@@ -17,5 +17,7 @@ jobs:
         run: yarn --frozen-lockfile
       - name: Build Style Dictionary
         run: yarn build
-      - name: Run linting
+      - name: Run eslint
         run: yarn lint
+      - name: Run Prettier Check
+        run: yarn prettier:check


### PR DESCRIPTION
## Description

Run prettier in CI so that code formatting is always enforced. This would happen either if someone used `--no-verify` or if they didn't npm install

## Screenshots

N/A

## Checklist

- [ ] Docs have been rebuilt (`yarn build:full`)
- [ ] All unit tests pass
- [ ] Snapshots have been updated
- [ ] No lint errors or warnings have been introduced
- [ ] **[Version bumped](https://github.com/cbinsights/form-design-system#updating-version-number) if appropriate**