### PR TITLE
ci(build): remove all builds in all other steps but release

### DIFF
--- a/.github/workflows/reusable-linting.yml
+++ b/.github/workflows/reusable-linting.yml
@@ -15,8 +15,6 @@ jobs:
           cache: 'yarn'
       - name: Yarn Install
         run: yarn --frozen-lockfile
-      - name: Build Style Dictionary
-        run: yarn build
       - name: Run eslint
         run: yarn lint
       - name: Run Prettier Check

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -14,19 +14,8 @@ jobs:
           node-version: '14.x'
           cache: 'yarn'
 
-      # - name: Cache Style Dictionary
-      #   id: cache-dictionary
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: ../lib
-      #     key: ${{ runner.os }}-${{ hashFiles('../src/components/**/*', '../src/base-styles/**/*', '../src/dictionary/**/*') }}
-
       - name: Yarn Install
         run: yarn --frozen-lockfile
-
-      - name: Build Style Dictionary
-        # if: steps.cache-dictionary.outputs.cache-hit != 'true'
-        run: yarn build
 
       - name: Run tests
         run: |

--- a/.github/workflows/reusable-typecheck.yml
+++ b/.github/workflows/reusable-typecheck.yml
@@ -15,7 +15,5 @@ jobs:
           cache: 'yarn'
       - name: Yarn Install
         run: yarn --frozen-lockfile
-      - name: Build Style Dictionary
-        run: yarn build
       - name: Run typecheck
         run: yarn tsc


### PR DESCRIPTION
builds are no longer needed in these steps becuase we no longer import dependencies from lib

#738