### PR TITLE
fix: nullable props on IconButton.

### DIFF
--- a/src/components/IconButton/index.tsx
+++ b/src/components/IconButton/index.tsx
@@ -36,9 +36,11 @@ export interface IconButtonProps {
   /** Accessibility label */
   label: string;
   /** Extend click radius of button to nearest relative parent */
-  isBreakoutLink: boolean;
+  isBreakoutLink?: boolean;
   /** URL for base element */
-  href: string;
+  href?: string;
+  /** Handler for on click event */
+  onClick?: () => void;
 }
 
 const IconButton = forwardRef(


### PR DESCRIPTION
`isBreakoutLink`, `href` & `onClick` props were overlooked on migration to typescript, and should have been nullable from the beginning.