### PR TITLE
test(tests): replaces "toBeTruthy" in tests with "toBeInTheDocument"

### DIFF
--- a/src/components/Avatar/index.test.tsx
+++ b/src/components/Avatar/index.test.tsx
@@ -77,6 +77,6 @@ describe('Avatar component', () => {
 
   it('renders placeholder if title or img not passed in', () => {
     render(<Avatar />);
-    expect(screen.getByTitle('Placeholder Avatar')).toBeTruthy();
+    expect(screen.getByTitle('Placeholder Avatar')).toBeInTheDocument();
   });
 });

--- a/src/components/Badge/index.test.tsx
+++ b/src/components/Badge/index.test.tsx
@@ -12,7 +12,7 @@ describe('Badge component', () => {
     const notif = container.querySelector(SELECTOR_NOTIF);
     const count = container.querySelector(SELECTOR_COUNT);
     expect(count).toBeFalsy();
-    expect(notif).toBeTruthy();
+    expect(notif).toBeInTheDocument();
     expect(notif).toHaveClass('color--white');
     expect(notif).toHaveClass('bgColor--red');
     expect(notif).not.toHaveClass('color--aqua');
@@ -30,7 +30,7 @@ describe('Badge component', () => {
   it('renders correctly as notif without label with showDot true', () => {
     const { container } = render(<Badge showDot={true} />);
     const notif = container.querySelector(SELECTOR_NOTIF);
-    expect(notif).toBeTruthy();
+    expect(notif).toBeInTheDocument();
   });
 
   it('renders correctly as count with label', () => {
@@ -38,7 +38,7 @@ describe('Badge component', () => {
     const notif = container.querySelector(SELECTOR_NOTIF);
     const count = container.querySelector(SELECTOR_COUNT);
     expect(notif).toBeFalsy();
-    expect(count).toBeTruthy();
+    expect(count).toBeInTheDocument();
     expect(count).toHaveClass('color--aqua');
     expect(count).not.toHaveClass('color--white');
     expect(count).not.toHaveClass('bgColor--red');

--- a/src/components/Button/index.test.tsx
+++ b/src/components/Button/index.test.tsx
@@ -7,7 +7,7 @@ describe('Button component', () => {
   it('tests default rendering', () => {
     render(<Button label="Button" />);
     const button = screen.getByRole('button', { name: 'Button' });
-    expect(button).toBeTruthy();
+    expect(button).toBeInTheDocument();
     expect(button).toHaveClass('fdsButton--m');
     expect(button).toHaveClass('fdsButton--blue');
     expect(button).not.toHaveClass('fdsButton--isDestructive');
@@ -17,12 +17,12 @@ describe('Button component', () => {
   it('tests rendering as link', () => {
     render(<Button label="Anchor" href="#" />);
     const link = screen.getByRole('link', { name: 'Anchor' });
-    expect(link).toBeTruthy();
+    expect(link).toBeInTheDocument();
   });
 
   it('tests that props get spread', () => {
     render(<Button label="Button" href="#" data-testid="test" />);
-    expect(screen.getByTestId('test')).toBeTruthy();
+    expect(screen.getByTestId('test')).toBeInTheDocument();
   });
 
   it('tests that proper theme gets applied', () => {

--- a/src/components/Checkbox/index.test.tsx
+++ b/src/components/Checkbox/index.test.tsx
@@ -64,7 +64,7 @@ describe('Checkbox component', () => {
       </>
     );
 
-    expect(screen.getByLabelText('Component label')).toBeTruthy();
-    expect(screen.getByLabelText('User label')).toBeTruthy();
+    expect(screen.getByLabelText('Component label')).toBeInTheDocument();
+    expect(screen.getByLabelText('User label')).toBeInTheDocument();
   });
 });

--- a/src/components/DateInput/index.test.js
+++ b/src/components/DateInput/index.test.js
@@ -67,7 +67,7 @@ describe('DateInput component', () => {
     expect(dateChangeFn).not.toHaveBeenCalled();
     expect(
       screen.getByRole('gridcell', { selected: true, name: 'Tue Jul 07 2020' })
-    ).toBeTruthy();
+    ).toBeInTheDocument();
     await userEvent.clear(screen.getByRole('textbox'));
     // did the callback fire with null?
     expect(dateChangeFn).toHaveBeenCalledWith(null);
@@ -82,7 +82,7 @@ describe('Date formats', () => {
   it('uses correct placeholder for a given format', () => {
     Object.keys(DATE_FORMAT_MAP).forEach((format) => {
       render(<DateInput dateFormat={format} />);
-      expect(screen.getByPlaceholderText(DATE_FORMAT_MAP[format])).toBeTruthy();
+      expect(screen.getByPlaceholderText(DATE_FORMAT_MAP[format])).toBeInTheDocument();
     });
   });
 
@@ -90,7 +90,7 @@ describe('Date formats', () => {
     const expectedValues = ['06/01/2020', '01/06/2020', '2020/06/01'];
     Object.keys(DATE_FORMAT_MAP).forEach((format, i) => {
       render(<DateInput dateFormat={format} defaultDate={new Date('June 1 2020')} />);
-      expect(screen.getByDisplayValue(expectedValues[i])).toBeTruthy();
+      expect(screen.getByDisplayValue(expectedValues[i])).toBeInTheDocument();
     });
   });
 });

--- a/src/components/Dialog/index.test.tsx
+++ b/src/components/Dialog/index.test.tsx
@@ -25,10 +25,10 @@ describe('Dialog', () => {
 
     /* Test that content renders properly */
     /* ================================== */
-    expect(screen.getByText('content')).toBeTruthy();
-    expect(screen.getByText('footerContent')).toBeTruthy();
-    expect(screen.getByText('title')).toBeTruthy();
-    expect(screen.getByText('subTitle')).toBeTruthy();
+    expect(screen.getByText('content')).toBeInTheDocument();
+    expect(screen.getByText('footerContent')).toBeInTheDocument();
+    expect(screen.getByText('title')).toBeInTheDocument();
+    expect(screen.getByText('subTitle')).toBeInTheDocument();
 
     /* Tests that onDismiss gets fired correctly */
     /* ========================================= */

--- a/src/components/DropdownButton/index.test.tsx
+++ b/src/components/DropdownButton/index.test.tsx
@@ -6,6 +6,6 @@ describe('DropdownButton component', () => {
   it('renders correctly', () => {
     render(<DropdownButton>Dropdown</DropdownButton>);
     const child = screen.getByText('Dropdown');
-    expect(child).toBeTruthy();
+    expect(child).toBeInTheDocument();
   });
 });

--- a/src/components/Loading/index.test.tsx
+++ b/src/components/Loading/index.test.tsx
@@ -6,6 +6,6 @@ import Loading from '.';
 describe('Loading component', () => {
   it('renders correctly as notif with label', () => {
     render(<Loading />);
-    expect(screen.getByRole('img')).toBeTruthy();
+    expect(screen.getByRole('img')).toBeInTheDocument();
   });
 });

--- a/src/components/Popover/index.test.tsx
+++ b/src/components/Popover/index.test.tsx
@@ -12,7 +12,7 @@ describe('Popover component', () => {
       </Popover>
     );
     expect(screen.queryByText('popover content')).toBeNull();
-    expect(screen.getByText('trigger')).toBeTruthy();
+    expect(screen.getByText('trigger')).toBeInTheDocument();
   });
 
   it('tests that trigger and content text gets rendered', () => {
@@ -21,8 +21,8 @@ describe('Popover component', () => {
         <p>popover content</p>
       </Popover>
     );
-    expect(screen.getByText('trigger')).toBeTruthy();
-    expect(screen.getByText('popover content')).toBeTruthy();
+    expect(screen.getByText('trigger')).toBeInTheDocument();
+    expect(screen.getByText('popover content')).toBeInTheDocument();
   });
 
   it('tests that onUserDismiss is called only once when clicking outside popover', async () => {
@@ -38,7 +38,7 @@ describe('Popover component', () => {
 
     userEvent.click(screen.getByText('trigger'));
     userEvent.click(screen.getByText('popover content'));
-    expect(screen.getByText('popover content')).toBeTruthy();
+    expect(screen.getByText('popover content')).toBeInTheDocument();
     userEvent.click(screen.getByText('outside click'));
     await waitFor(() => expect(screen.queryByText('popover content')).toBeNull());
 
@@ -57,7 +57,7 @@ describe('Popover component', () => {
     );
 
     userEvent.click(screen.getByText('trigger'));
-    expect(screen.getByText('popover content')).toBeTruthy();
+    expect(screen.getByText('popover content')).toBeInTheDocument();
     userEvent.type(document.body, '{esc}');
     await waitFor(() => expect(screen.queryByText('popover content')).toBeNull());
 

--- a/src/components/Tooltip/index.test.js
+++ b/src/components/Tooltip/index.test.js
@@ -8,7 +8,7 @@ describe('Tooltip component', () => {
     render(<Tooltip trigger={<button>trigger</button>} message="lol" />);
     userEvent.hover(screen.getByText('trigger'));
     await waitFor(() => {
-      expect(screen.getByText('lol')).toBeTruthy();
+      expect(screen.getByText('lol')).toBeInTheDocument();
     });
   });
 });

--- a/src/components/ZeroState/index.test.tsx
+++ b/src/components/ZeroState/index.test.tsx
@@ -7,7 +7,7 @@ describe('<ZeroState />', () => {
   describe('if label is provided', () => {
     it('should render label', () => {
       render(<ZeroState label="Hello World" />);
-      expect(screen.getByText('Hello World')).toBeTruthy();
+      expect(screen.getByText('Hello World')).toBeInTheDocument();
       expect(screen.queryByRole('img')).toBeNull();
     });
   });
@@ -15,7 +15,7 @@ describe('<ZeroState />', () => {
   describe('if Icon is provided', () => {
     it('should render icon', () => {
       render(<ZeroState Icon={TableIcon} />);
-      expect(screen.getByRole('img')).toBeTruthy();
+      expect(screen.getByRole('img')).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
fixes #781

