### PR TITLE
ci(workflow): point to master for cypress test in ci

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,4 +12,4 @@ jobs:
   lint:
     uses: cbinsights/form-design-system/.github/workflows/reusable-linting.yml@master
   cypress-test:
-    uses: cbinsights/form-design-system/.github/workflows/cypress-test.yml@add-cypress-to-ci
+    uses: cbinsights/form-design-system/.github/workflows/cypress-test.yml@master


### PR DESCRIPTION
fixes #998

