### PR TITLE
fix(button): text color for isDestructive outlined and ghost styles

### DIFF
--- a/src/components/style/button.css
+++ b/src/components/style/button.css
@@ -346,7 +346,9 @@
   border-color: var(--color-red);
 }
 
-.fdsButton--isDestructive:matches(.fdsButton--outlined, .fdsButton--outlined--blue, .fdsButton--ghost) {
+.fdsButton--outlined.fdsButton--isDestructive,
+.fdsButton--outlined--blue.fdsButton--isDestructive,
+.fdsButton--ghost.fdsButton--isDestructive {
   color: var(--color-red);
 }
 


### PR DESCRIPTION
using git bisect i found the first bad commit to be 8374684c75fb798606834e0e852c6ee5bab17a8f - "update postcss (major)". The issue did not resolve when i reverted back to the original versions of postcss. Adding css without the 'matches'  pseudo-class seems to do the trick though.