### PR TITLE
feat(menu): allow to use "modal" property in Dropdown Menu

### DIFF
--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -4,11 +4,11 @@ import Item from './MenuItem';
 import Trigger from './MenuTrigger';
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
 
-export type MenuProps = Omit<DropdownMenu.DropdownMenuProps, 'modal' | 'dir'>;
+export type MenuProps = Omit<DropdownMenu.DropdownMenuProps, 'dir'>;
 
-const Menu = ({ children, ...rest }: MenuProps): JSX.Element => {
+const Menu = ({ children, modal = true, ...rest }: MenuProps): JSX.Element => {
   return (
-    <DropdownMenu.Root {...rest} modal dir={'ltr'}>
+    <DropdownMenu.Root {...rest} modal={modal} dir={'ltr'}>
       {children}
     </DropdownMenu.Root>
   );


### PR DESCRIPTION
The "modal" property is causing performance problems in some cbi-site views that have a large volume of html elements. This change allows to send the value of the "modal" property that is required according to the implementation.