### PR TITLE
fix(popover): fix popover wrapper style

### DIFF
--- a/src/base-styles/helperClasses/layout/width.css
+++ b/src/base-styles/helperClasses/layout/width.css
@@ -9,3 +9,7 @@
 .div--100 {
   width: 100%;
 }
+
+.width--fit {
+  width: fit-content;
+}

--- a/src/components/Popover/index.tsx
+++ b/src/components/Popover/index.tsx
@@ -193,7 +193,7 @@ const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(
     return (
       <RadixPopover.Root open={isActive} onOpenChange={handleChange}>
         <RadixPopover.Trigger asChild>
-          <div className="display--inlineFlex div--100">{clonedTrigger}</div>
+          <div className="display--flex width--fit">{clonedTrigger}</div>
         </RadixPopover.Trigger>
         <RadixPopover.Content
           ref={refContent}


### PR DESCRIPTION
We had a style problem with the inline-flex and width:100% added to the popover trigger. I changed the style to be `display:flex` and `width:fit-content` and it seems to work in all the cases I tested it.